### PR TITLE
preserve props children for compatibility with react

### DIFF
--- a/packages/inferno-compat/src/index.js
+++ b/packages/inferno-compat/src/index.js
@@ -94,6 +94,12 @@ const injectStringRefs = (originalFunction) => {
 		if (typeof name === 'string') {
 			normalizeProps(name, props);
 		}
+		if (children && children.length > 0) {
+			if (isNullOrUndef(props)) {
+				props = {};
+			}
+			props.children = children; // this should allow it to work with Radium Enhancer
+		}
 		return originalFunction(name, props, ...children);
 	};
 };


### PR DESCRIPTION
 *Before* submitting a PR please:
 v Make sure you have based your branch off the [dev branch](https://github.com/trueadm/inferno/tree/dev).
 v Submit your PR against the [dev branch](https://github.com/trueadm/inferno/tree/dev).
 v Run `npm run build` and check that the build succeeds.
 v Ensure that the PR hasn't been submitted before.

---

## PR Template

**Objective**

This PR is intended to improve the compatibility against Radium. Radium Enhancer wraps components through props.children (https://github.com/FormidableLabs/radium/blob/9c61f148d51a611af24705fee7f4d9734d336526/src/resolve-styles.js#L326) but for some reason inferno's createElement and clonevNode doesn't handle props.children as gracefully. 
The issue only surfaces with Radium components usage as far as my testing goes. That's why I limit the scope of this PR to inferno-compat.

**Closes Issue**

It may relate to issue #635 
