### PR TITLE
fix router bug

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -80,6 +80,7 @@
 		"wrap-iife": [2, "inside"],
 		"yoda": 2,
 		"strict": [2, "never"],
+		"no-mixed-operators": 2,
 		"no-delete-var": 2,
 		"no-shadow-restricted-names": 2,
 		"no-unused-vars": 0,

--- a/src/router/utils.ts
+++ b/src/router/utils.ts
@@ -90,7 +90,7 @@ export function pathRankSort(a: any, b: any) {
 	const aAttr = a.props || emptyObject;
 	const bAttr = b.props || emptyObject;
 	const diff = rank(bAttr.path) - rank(aAttr.path);
-	return diff || (bAttr.path && aAttr.path) ? (bAttr.path.length - aAttr.path.length) : 0;
+	return diff || ((bAttr.path && aAttr.path) ? (bAttr.path.length - aAttr.path.length) : 0);
 }
 
 /**


### PR DESCRIPTION
This
```
return diff || (bAttr.path && aAttr.path) ? (bAttr.path.length - aAttr.path.length) : 0
```
is being interpreted as
```
return (diff || (bAttr.path && aAttr.path)) ? (bAttr.path.length - aAttr.path.length) : 0
```
not
```
return diff || ((bAttr.path && aAttr.path) ? (bAttr.path.length - aAttr.path.length) : 0)
```
and then I get the error that it cant read length of undefined.

The router would only bug if i had two routes like this

- /5char

- /fivec/:foo

It was 5 chars that broke but from what I could read of the code any equal length would bug the sorting.