### PR TITLE
Devtools: Pass defaultProps into component wrapper

### DIFF
--- a/src/devtools/init.ts
+++ b/src/devtools/init.ts
@@ -32,6 +32,7 @@ function wrapFunctionalComponent(vNode) {
 		wrappers.set(originalRender, wrapper);
 	}
 	vNode.type = wrappers.get(originalRender);
+	vNode.type.defaultProps = originalRender.defaultProps;
 	vNode.ref = null;
 	vNode.flags = VNodeFlags.ComponentClass;
 }


### PR DESCRIPTION
**Objective**

Support defaultProps on functional components when `inferno-devtools` has been imported into a project.

**Closes Issue**

No filed issue.
