### PR TITLE
remove props.ref & props.key

### DIFF
--- a/src/core/normalization.ts
+++ b/src/core/normalization.ts
@@ -88,7 +88,10 @@ function normalizeProps(vNode: VNode, props: Props, children: InfernoChildren) {
 		vNode.children = props.children;
 	}
 	if (props.ref) {
-		vNode.ref = props.ref;
+		delete props.ref;
+	}
+	if (props.key) {
+		delete props.key;
 	}
 	if (props.events) {
 		vNode.events = props.events;


### PR DESCRIPTION
**Objective**

Removes `props.key` and `props.ref` for compat builds. Stays true to React behavior.

**Closes Issue**

It closes Issue #648 
