### PR TITLE
fix(normalization): issue-648, remove props.key and props.ref

### DIFF
--- a/src/core/__tests__/normalizeProps.spec.tsx
+++ b/src/core/__tests__/normalizeProps.spec.tsx
@@ -1,0 +1,39 @@
+import { expect } from 'chai';
+import { normalize } from '../normalization';
+import { VNode } from '../structures';
+
+describe('normalizeProps', () => {
+	it('should delete ref from props', () => {
+		const vNode: VNode = {
+			children: null,
+			dom: null,
+			events: null,
+			flags: 0,
+			key: null,
+			props: { ref: () => {} },
+			ref: null,
+			type: null
+		};
+
+		normalize(vNode);
+
+		expect(vNode.props).to.not.have.property('ref');
+	});
+
+	it('should delete key from props', () => {
+		const vNode: VNode = {
+			children: null,
+			dom: null,
+			events: null,
+			flags: 0,
+			key: null,
+			props: { key: 'key' },
+			ref: null,
+			type: null
+		};
+
+		normalize(vNode);
+
+		expect(vNode.props).to.not.have.property('key');
+	});
+});

--- a/src/core/normalization.ts
+++ b/src/core/normalization.ts
@@ -88,16 +88,15 @@ function normalizeProps(vNode: VNode, props: Props, children: InfernoChildren) {
 		vNode.children = props.children;
 	}
 	if (props.ref) {
+		vNode.ref = props.ref;
 		delete props.ref;
-	}
-	if (props.key) {
-		delete props.key;
 	}
 	if (props.events) {
 		vNode.events = props.events;
 	}
 	if (!isNullOrUndef(props.key)) {
 		vNode.key = props.key;
+		delete props.key;
 	}
 }
 


### PR DESCRIPTION
**Objective**

This PR contains fix for PR https://github.com/infernojs/inferno/pull/651 which introduced new error: ref functions are not invoked
![image](https://cloud.githubusercontent.com/assets/12293945/21561274/b708f964-ce7b-11e6-950b-457f69df8e64.png)

**Closes Issue**

It closes Issue https://github.com/infernojs/inferno/issues/648
