### PR TITLE
Add ability to Route to accept getComponent

### DIFF
--- a/src/router/Route.ts
+++ b/src/router/Route.ts
@@ -12,12 +12,16 @@ export interface IRouteProps {
 	onLeave?: IRouteHook;
 	path: string;
 	children: Array<Component<any, any>>;
-	component: Component<any, any>;
+	component?: Component<any, any>;
+	getComponent(nextState: any, callback: (error: any, comp: Component<any, any>) => void): void;
 }
 
 export default class Route extends Component<IRouteProps, any> {
 	constructor(props?: IRouteProps, context?: any) {
 		super(props, context);
+		this.state = {
+			asyncComponent: null
+		};
 	}
 
 	componentWillMount() {
@@ -29,6 +33,19 @@ export default class Route extends Component<IRouteProps, any> {
 				onEnter({ props: this.props, router });
 			});
 		}
+
+		const { getComponent } = this.props;
+		if (getComponent) {
+			Promise.resolve().then(() => {
+				getComponent({ props: this.props, router }, this.onComponentResolved);
+			});
+		}
+	}
+
+	onComponentResolved = (error, component) => {
+		this.setState({
+			asyncComponent: component
+		});
 	}
 
 	onLeave(trigger = false) {
@@ -52,6 +69,13 @@ export default class Route extends Component<IRouteProps, any> {
 		const { component, children } = _args;
 		const props = rest(_args, ['component', 'children', 'path']);
 
-		return createElement(component, props, children);
+		const { asyncComponent } = this.state;
+
+		const resolvedComponent = component || asyncComponent;
+		if (!resolvedComponent) {
+			return null;
+		}
+
+		return createElement(resolvedComponent, props, children);
 	}
 }

--- a/src/router/Route.ts
+++ b/src/router/Route.ts
@@ -37,12 +37,12 @@ export default class Route extends Component<IRouteProps, any> {
 		const { getComponent } = this.props;
 		if (getComponent) {
 			Promise.resolve().then(() => {
-				getComponent({ props: this.props, router }, this.onComponentResolved);
+				getComponent({ props: this.props, router }, this._onComponentResolved);
 			});
 		}
 	}
 
-	onComponentResolved = (error, component) => {
+	private _onComponentResolved = (error, component) => {
 		this.setState({
 			asyncComponent: component
 		});

--- a/src/router/__tests__/transition.spec.tsx
+++ b/src/router/__tests__/transition.spec.tsx
@@ -191,6 +191,19 @@ describe('Router (jsx) #transitions', () => {
 			<Route path='/' onEnter={ null } onLeave={ null } component={ TestHooksLeave }/>
 		</Router>, container);
 	});
+
+	it('should support getComponent as an alternative to the component prop', (done) => {
+		const resolveToComponent = (nextState, cb) => cb(null, GoodComponent);
+
+		render(<Router history={ browserHistory }>
+				<Route path={'/'} getComponent={resolveToComponent}/>
+			</Router>, container);
+
+		setTimeout(() => {
+			expect(container.innerHTML).to.equal(innerHTML('<div>Good Component</div>'));
+			done();
+		}, 10);
+	});
 });
 
 function clickOnLink(element) {


### PR DESCRIPTION
## Add support for getComponent in inferno-router

**Objective**

First of all, I want to say that I think this project is awesome! So good job so far 👍 

In a personal project, I was missing the `getComponent` feature from react-router. It is very useful for code-splitting, and would remove the need for some workarounds I had to do instead.

This is my first PR, and I tried to follow your guide as much as possible. I hope this PR aligns with your vision for the project.