### PR TITLE
Implement iOS onClick bug workaround

### DIFF
--- a/src/DOM/events/delegation.ts
+++ b/src/DOM/events/delegation.ts
@@ -19,6 +19,9 @@ export function handleEvent(name, lastEvent, nextEvent, dom) {
 		}
 		if (!lastEvent) {
 			delegatedRoots.count++;
+			if (name === 'onClick') {
+				trapClickOnNonInteractiveElement(dom);
+			}
 		}
 		delegatedRoots.items.set(dom, nextEvent);
 	} else if (delegatedRoots) {
@@ -85,4 +88,17 @@ function attachEventToDocument(name, delegatedRoots) {
 	};
 	document.addEventListener(normalizeEventName(name), docEvent);
 	return docEvent;
+}
+
+function trapClickOnNonInteractiveElement(dom) {
+	// Mobile Safari does not fire properly bubble click events on
+	// non-interactive elements, which means delegated click listeners do not
+	// fire. The workaround for this bug involves attaching an empty click
+	// listener on the target node.
+	// http://www.quirksmode.org/blog/archives/2010/09/click_event_del.html
+	// Just set it using the onclick property so that we don't have to manage any
+	// bookkeeping for it. Not sure if we need to clear it when the listener is
+	// removed.
+	// TODO: Only do this for the relevant Safaris maybe?
+	dom.onclick = () => {};
 }

--- a/src/DOM/events/delegation.ts
+++ b/src/DOM/events/delegation.ts
@@ -1,3 +1,6 @@
+import { isBrowser } from '../../shared';
+
+const isiOS = isBrowser && !!navigator.platform && /iPad|iPhone|iPod/.test(navigator.platform);
 const delegatedEvents = new Map();
 
 interface IDelegate {
@@ -19,7 +22,7 @@ export function handleEvent(name, lastEvent, nextEvent, dom) {
 		}
 		if (!lastEvent) {
 			delegatedRoots.count++;
-			if (name === 'onClick') {
+			if (isiOS && name === 'onClick') {
 				trapClickOnNonInteractiveElement(dom);
 			}
 		}


### PR DESCRIPTION
This resolves issue #671 by trapping clicks on non-interactive DOM components where `onClick` is used.