### PR TITLE
inferno.d.ts: Fix 'inferno-server' types

### DIFF
--- a/src/inferno.d.ts
+++ b/src/inferno.d.ts
@@ -113,8 +113,13 @@ declare module 'inferno-component' {
 }
 
 declare module 'inferno-server' {
-	export function renderToStaticMarkup(...rest);
-	export default function renderToString(...rest);
+	export function renderToString(...rest);
+ 	export function renderToStaticMarkup(...rest);
+
+	export default {
+		renderToString(...rest),
+		renderToStaticMarkup(...rest),
+	}
 }
 
 declare module 'inferno-create-class' {


### PR DESCRIPTION
'renderToString' was not the default export. Default export is an object with 'renderToString' and 'renderToStaticMarkup', with both also being named exports.

---

## PR Template

**Objective**

This PR improves TypeScript types. Contributes to issue #628.
