### PR TITLE
Fix bug in hyperscript with props.children

### DIFF
--- a/src/factories/hyperscript.ts
+++ b/src/factories/hyperscript.ts
@@ -53,14 +53,14 @@ function isChildren(x: any): boolean {
 	return isStringOrNumber(x) || (x && isArray(x));
 }
 
-function extractProps(_props: any, _tag: string | VNode): any {
+function extractProps(_props: any, _tag: string | VNode, _children?: InfernoChildren): any {
 	_props = _props || {};
 	const isComponent = !isString(_tag);
 	const tag = !isComponent ? parseTag(_tag as string, _props) : _tag;
 	const props = {};
 	let key = null;
 	let ref = null;
-	let children = null;
+	let children = _children;
 	let events = null;
 
 	for (let prop in _props) {
@@ -95,7 +95,7 @@ export default function hyperscript(_tag: string | VNode, _props?: any, _childre
 		_children = _props;
 		_props = {};
 	}
-	const { tag, props, key, ref, children, events } = extractProps(_props, _tag);
+	const { tag, props, key, ref, children, events } = extractProps(_props, _tag, _children);
 
 	if (isString(tag)) {
 		let flags = VNodeFlags.HtmlElement;


### PR DESCRIPTION
inferno-hyperscript does not provide children as props.children to components unless the parent explicitly passes them as a prop. This breaks libraries and code that use `props.children` in any way. For example,

```javascript
h(Parent, [
    h(Child),
])
```

In the above example, `props.children` resolves to null inside `Parent` component but it is expected to be `[h(Child)]`. This works correctly in React, Preact and inferno-create-element but not in inferno-hyperscript.

This commit fixes the bug in inferno-hyperscript so it always provides the children as `props.children` to all components just like inferno-create-element.

This will fix the discrepancy between inferno-hyperscript and inferno-create-element, and improve compatibility with react/preact libraries that ship higher-order components. For example, this fix will make react-toolbox's `Card` component work with inferno.