### PR TITLE
Fixed a normalization warning logging typo

### DIFF
--- a/src/core/normalization.ts
+++ b/src/core/normalization.ts
@@ -183,7 +183,7 @@ export function normalize(vNode: VNode): void {
 			keyValues.some(function(item, idx){
 				const hasDuplicate = keyValues.indexOf(item) !== idx;
 
-				warning(!hasDuplicate, 'Infreno normalisation(...): Encountered two children with same key, all keys must be unique within its siblings. Duplicated key is:' + item);
+				warning(!hasDuplicate, 'Inferno normalisation(...): Encountered two children with same key, all keys must be unique within its siblings. Duplicated key is:' + item);
 
 				return hasDuplicate;
 			});


### PR DESCRIPTION
**Objective**

This PR fixes a typo in normalization warning logging, `Infreno` →  `Inferno`

