### PR TITLE
Fixed strict mode error running in PhantomJS

### DIFF
--- a/src/core/normalization.ts
+++ b/src/core/normalization.ts
@@ -178,7 +178,7 @@ export function normalize(vNode: VNode): void {
 		// This code will be stripped out from production CODE
 		// It will help users to track errors in their applications.
 
-		function verifyKeys(vNodes) {
+		const verifyKeys = function(vNodes) {
 			const keyValues = vNodes.map(function(vnode){ return vnode.key; });
 			keyValues.some(function(item, idx){
 				const hasDuplicate = keyValues.indexOf(item) !== idx;
@@ -187,7 +187,7 @@ export function normalize(vNode: VNode): void {
 
 				return hasDuplicate;
 			});
-		}
+		};
 
 		if (vNode.children && Array.isArray(vNode.children)) {
 			verifyKeys(vNode.children);


### PR DESCRIPTION
**Objective**

When running tests in PhantomJS with Inferno v1.1.1, I'm seeing the following error:

```
PhantomJS 2.1.1 (Windows 8 0.0.0) ERROR
  SyntaxError: Functions cannot be declared in a nested block in strict mode
  at webpack:///~/inferno/dist/inferno.node.js:227:0 <- tests/App-test.js:4384
```

See also this [failing nwb build](https://travis-ci.org/insin/nwb/jobs/190135501#L2479).

This change fixed it for me running locally.