### PR TITLE
fixed issue where inferno-router ignored meta+click to open link in new tab

### DIFF
--- a/src/router/Link.ts
+++ b/src/router/Link.ts
@@ -29,7 +29,7 @@ export default function Link(props, { router }) {
 	}
 
 	elemProps.onclick = function navigate(e) {
-		if (e.button !== 0 || e.ctrlKey || e.altKey) {
+		if (e.button !== 0 || e.ctrlKey || e.altKey || e.metaKey || e.shiftKey) {
 			return;
 		}
 		e.preventDefault();


### PR DESCRIPTION
**Objective**

This PR skips pushing onto history for meta+click events. These types of events have different meanings in the browser, usually opening a new tab or window, so we should not be capturing them in the inferno router. This is the [same behavior as react-router](https://github.com/ReactTraining/react-router/blob/master/modules/Link.js#L13). 

**Closes Issue**

It closes Issue #701 
