### PR TITLE
Fix onEnter/onLeave example in readme

### DIFF
--- a/packages/inferno-router/README.md
+++ b/packages/inferno-router/README.md
@@ -159,13 +159,13 @@ function Home({ params }) {
   // ...
 }
 
-function authorizedOnly(props, router) {
+function authorizedOnly({ props, router }) {
   if (!props.loggedIn) {
     router.push('/login');
   }
 }
 
-function sayGoodBye(props, router) {
+function sayGoodBye({ props, router }) {
   alert('Good bye!')
 }
 


### PR DESCRIPTION
This PR fixes the example code on how to use onEnter or onLeave hooks in inferno-router Readme. onEnter and onLeave return an object based on https://github.com/infernojs/inferno/pull/470.
