### PR TITLE
Fix missing query parameters when URL is changed by using the history API

### DIFF
--- a/src/router/Router.ts
+++ b/src/router/Router.ts
@@ -48,8 +48,8 @@ export default class Router extends Component<IRouterProps, any> {
 
 	componentWillMount() {
 		if (this.router) {
-			this.unlisten = this.router.listen((url) => {
-				this.routeTo(url.pathname);
+			this.unlisten = this.router.listen(() => {
+				this.routeTo(this.router.url);
 			});
 		}
 	}

--- a/src/router/__tests__/transition.spec.tsx
+++ b/src/router/__tests__/transition.spec.tsx
@@ -201,6 +201,24 @@ describe('Router (jsx) #transitions', () => {
 			done();
 		}, 10);
 	});
+
+	it('should passed query parameters when URL is changed by using the history API', (done) => {
+		const TestQueryParams = ({ params }) => <div>Query Params { params.foo }</div>;
+
+		render(
+			<Router history={ browserHistory }>
+				<IndexRoute component={ TestQueryParams } />
+			</Router>,
+			container,
+		);
+
+		browserHistory.push('/?foo=Bar');
+
+		setTimeout(() => {
+			expect(container.innerHTML).to.equal(innerHTML('<div>Query Params Bar</div>'));
+			done();
+		}, 10);
+	});
 });
 
 function clickOnLink(element) {


### PR DESCRIPTION
**Objective**

This PR fix missing query parameters when URL is changed by using the history API