### PR TITLE
Remove not existing functions

### DIFF
--- a/packages/inferno-test-utils/README.md
+++ b/packages/inferno-test-utils/README.md
@@ -11,15 +11,13 @@ npm install inferno inferno-test-utils
 
 ## Contents
 
-* shallowRender
-* deepRender
 * renderIntoDocument
 
 ## Usage
 
 ```js
 import Inferno from 'inferno';
-import { shallowRender } from 'inferno-test-utils';
+import { renderIntoDocument } from 'inferno-test-utils';
 
-const output = shallowRender(<div>Hello world</div>);
+const output = renderIntoDocument(<div>Hello world</div>);
 ```


### PR DESCRIPTION
Hello,

the inferno-test-utils documentation mention deepRender and shallowRender function but I can find them in the package. I finally see in the website documentation that shallow rendering is not supported yet here https://infernojs.org/docs/api/inferno-test-utils.

Maybe remove these functions from the doc will be a good idea ?
The link of the documentation https://github.com/infernojs/inferno/tree/master/packages/inferno-test-utils in github. 