### PR TITLE
Fix for issue #778

### DIFF
--- a/package.json
+++ b/package.json
@@ -95,7 +95,7 @@
     "typescript": "^2.1.5",
     "union-type-es": "^0.1.0",
     "webpack": "2.2.1",
-    "webpack-dev-server": "2.2.0"
+    "webpack-dev-server": "2.2.1"
   },
   "files": [
     "src"

--- a/package.json
+++ b/package.json
@@ -94,7 +94,7 @@
     "tslint": "^4.3.1",
     "typescript": "^2.1.5",
     "union-type-es": "^0.1.0",
-    "webpack": "2.2.0",
+    "webpack": "2.2.1",
     "webpack-dev-server": "2.2.0"
   },
   "files": [

--- a/src/DOM/__tests__/children.spec.tsx
+++ b/src/DOM/__tests__/children.spec.tsx
@@ -1064,13 +1064,13 @@ describe('Children - (JSX)', () => {
 				</div>
 			);
 
-			render(<Nodes items={[1,2,3]}/>, container);
+			render(<Nodes items={[1, 2, 3]}/>, container);
 			expect(container.innerHTML).to.equal(innerHTML('<div><div>test</div><span>1</span><span>2</span><span>3</span><div>end</div></div>'));
 
-			render(<Nodes items={[3,2,1]}/>, container);
+			render(<Nodes items={[3, 2, 1]}/>, container);
 			expect(container.innerHTML).to.equal(innerHTML('<div><div>test</div><span>3</span><span>2</span><span>1</span><div>end</div></div>'));
 
-			render(<Nodes items={[9,8,7]}/>, container);
+			render(<Nodes items={[9, 8, 7]}/>, container);
 			expect(container.innerHTML).to.equal(innerHTML('<div><div>test</div><span>9</span><span>8</span><span>7</span><div>end</div></div>'));
 
 			render(<Nodes items={[]}/>, container);
@@ -1086,13 +1086,13 @@ describe('Children - (JSX)', () => {
 				</div>
 			);
 
-			render(<Nodes items={[1,2,3]}/>, container);
+			render(<Nodes items={[1, 2, 3]}/>, container);
 			expect(container.innerHTML).to.equal(innerHTML('<div><div>test</div><span>1</span><span>2</span><span>3</span><div>end</div></div>'));
 
-			render(<Nodes items={[3,2,1]}/>, container);
+			render(<Nodes items={[3, 2, 1]}/>, container);
 			expect(container.innerHTML).to.equal(innerHTML('<div><div>test</div><span>3</span><span>2</span><span>1</span><div>end</div></div>'));
 
-			render(<Nodes items={[9,8,7]}/>, container);
+			render(<Nodes items={[9, 8, 7]}/>, container);
 			expect(container.innerHTML).to.equal(innerHTML('<div><div>test</div><span>9</span><span>8</span><span>7</span><div>end</div></div>'));
 
 			render(<Nodes items={[]}/>, container);

--- a/src/DOM/__tests__/clonenode.spec.tsx
+++ b/src/DOM/__tests__/clonenode.spec.tsx
@@ -15,7 +15,7 @@ describe('CloneVNode use cases', () => {
 	it('Should be able to render hoisted node', () => {
 		const a = ['foo', 'bar'];
 
-		render(<div>{[a,a,a,a]}</div>, container);
+		render(<div>{[a, a, a, a]}</div>, container);
 
 		expect(container.innerHTML).to.eql('<div>foobarfoobarfoobarfoobar</div>');
 	});

--- a/src/router/Route.ts
+++ b/src/router/Route.ts
@@ -55,11 +55,31 @@ export default class Route extends Component<IRouteProps, any> {
 		}
 	}
 
+	onEnter(nextProps) {
+		const { onEnter } = nextProps;
+		const { router } = this.context;
+
+		if (this.props.path !== nextProps.path && onEnter) {
+			onEnter({ props: nextProps, router });
+		}
+	}
+
+	getComponent(nextProps) {
+		const { getComponent } = nextProps;
+		const { router } = this.context;
+
+		if (this.props.path !== nextProps.path && getComponent) {
+			getComponent({ props: nextProps, router }, this._onComponentResolved);
+		}
+	}
+
 	componentWillUnmount() {
 		this.onLeave(true);
 	}
 
-	componentWillReceiveProps(nextProps) {
+	componentWillReceiveProps(nextProps: IRouteProps) {
+		this.getComponent(nextProps);
+		this.onEnter(nextProps);
 		this.onLeave(this.props.path !== nextProps.path);
 	}
 


### PR DESCRIPTION
**Objective**

This PR aims to fix #778. 

The `Route` props `onEnter` and `getComponent` were only called when the route that had these props was the first route to be activated when entering the page (as is stated in issue #778, `getComponent` was only called on hard refresh)

**Closes Issue**

Closes issue #778

**N.B**: I had to make changes to the files in `src/DOM/__tests__` because they would cause linting to fail 
