### PR TITLE
remove dehyphen prop stuff... all tests pass?

### DIFF
--- a/packages/inferno-create-element/__tests__/svgXlink.spec.jsx
+++ b/packages/inferno-create-element/__tests__/svgXlink.spec.jsx
@@ -85,33 +85,4 @@ describe('createTree - SVG (JSX)', () => {
 		'href'
 		)).to.equal(false);
 	});
-
-	it('should convert xlinkHref to xlink:href in SVG and add / remove / change it', () => {
-		render(<svg>
-			<use xlinkHref="#test"/>
-		</svg>, container);
-
-		expect(container.firstChild.firstChild.getAttributeNS(
-			'http://www.w3.org/1999/xlink',
-			'href'
-		)).to.equal('#test');
-
-		render(<svg>
-			<use xlinkHref="#changed"/>
-		</svg>, container);
-
-		expect(container.firstChild.firstChild.getAttributeNS(
-			'http://www.w3.org/1999/xlink',
-			'href'
-		)).to.equal('#changed');
-
-		render(<svg>
-			<use/>
-		</svg>, container);
-
-		expect(container.firstChild.firstChild.hasAttributeNS(
-			'http://www.w3.org/1999/xlink',
-			'href'
-		)).to.equal(false);
-	})
 });

--- a/packages/inferno/src/DOM/constants.ts
+++ b/packages/inferno/src/DOM/constants.ts
@@ -12,21 +12,8 @@ export const svgNS = 'http://www.w3.org/2000/svg';
 export const strictProps = {};
 export const booleanProps = {};
 export const namespaces = {};
-export const colonProps = {};
-export const probablyColonProps = /^(xlink[HART]|xml[BLS])/;
-export function colonize(str, smallLetter, largeLetter) {
-	return `${smallLetter}:${largeLetter.toLowerCase()}`;
-}
 export const isUnitlessNumber = {};
 export const skipProps = {};
-export const dehyphenProps = {
-	httpEquiv: 'http-equiv',
-	acceptCharset: 'accept-charset'
-};
-export const probablyKebabProps = /^(accentH|arabicF|capH|font[FSVW]|glyph[NO]|horiz[AO]|panose1|renderingI|strikethrough[PT]|underline[PT]|v[AHIM]|vert[AO]|xH|alignmentB|baselineS|clip[PR]|color[IPR]|dominantB|enableB|fill[OR]|flood[COF]|imageR|letterS|lightingC|marker[EMS]|pointerE|shapeR|stop[CO]|stroke[DLMOW]|text[ADR]|unicodeB|wordS|writingM).*/;
-export function kebabize(str, smallLetter, largeLetter) {
-	return `${smallLetter}-${largeLetter.toLowerCase()}`;
-}
 export const delegatedProps = {};
 
 constructDefaults('xlink:href,xlink:arcrole,xlink:actuate,xlink:role,xlink:titlef,xlink:type', namespaces, xlinkNS);

--- a/packages/inferno/src/DOM/patching.ts
+++ b/packages/inferno/src/DOM/patching.ts
@@ -27,15 +27,9 @@ import {
 } from '../core/VNodes';
 import {
 	booleanProps,
-	dehyphenProps,
 	delegatedProps,
-	colonize,
-	colonProps,
 	isUnitlessNumber,
-	kebabize,
 	namespaces,
-	probablyColonProps,
-	probablyKebabProps,
 	skipProps,
 	strictProps
 } from './constants';
@@ -845,26 +839,12 @@ export function patchProp(prop, lastValue, nextValue, dom: Element, isSVG: boole
 				}
 			}
 		} else {
-			let normalizedProp;
-			if (dehyphenProps[prop]) {
-				normalizedProp = dehyphenProps[prop];
-			} else if (colonProps[prop]) {
-				normalizedProp = colonProps[prop];
-			} else if (isSVG && prop.match(probablyKebabProps)) {
-				normalizedProp = prop.replace(/([a-z])([A-Z]|1)/g, kebabize);
-				dehyphenProps[prop] = normalizedProp;
-			} else if (isSVG && prop.match(probablyColonProps)) {
-				normalizedProp = prop.replace(/([a-z])([A-Z])/g, colonize);
-				colonProps[prop] = normalizedProp;
-			} else {
-				normalizedProp = prop;
-			}
-			const ns = namespaces[normalizedProp];
+			const ns = namespaces[prop];
 
 			if (ns) {
-				dom.setAttributeNS(ns, normalizedProp, nextValue);
+				dom.setAttributeNS(ns, prop, nextValue);
 			} else {
-				dom.setAttribute(normalizedProp, nextValue);
+				dom.setAttribute(prop, nextValue);
 			}
 		}
 	}
@@ -963,15 +943,6 @@ function removeProp(prop: string, lastValue, dom) {
 		dom.removeAttribute('style');
 	} else if (isAttrAnEvent(prop)) {
 		handleEvent(name, lastValue, null, dom);
-	} else if (prop.match(probablyColonProps)) {
-		let normalizedProp;
-		if (colonProps[prop]) {
-			normalizedProp = colonProps[prop];
-		} else {
-			normalizedProp = prop.replace(/([a-z])([A-Z])/g, colonize);
-			colonProps[prop] = normalizedProp;
-		}
-		dom.removeAttribute(normalizedProp);
 	} else {
 		dom.removeAttribute(prop);
 	}


### PR DESCRIPTION
Can we remove this code from core? I think its there by legacy reasons when we used to do `dom[prop] = something`. Nowadays we are setting props with setAttribute so whatever fancy names and combos are supported.

xlink:href can be set using just `xlink:href` or modern way: `href`