### PR TITLE
Router fixes

### DIFF
--- a/packages/inferno-router/__tests__/router.spec.jsx
+++ b/packages/inferno-router/__tests__/router.spec.jsx
@@ -1,12 +1,13 @@
 import {
 	expect
 } from 'chai';
-import createMemoryHistory from 'history/createMemoryHistory';
+import { createMemoryHistory, createBrowserHistory } from 'history';
 import { cloneVNode, render } from 'inferno';
 import { innerHTML } from 'inferno/test/utils';
-import { IndexRoute, Route, Router, RouterContext } from '../dist-es';
+import { IndexRoute, Route, Router, RouterContext, Link } from '../dist-es';
 
-const browserHistory = createMemoryHistory();
+const browserHistory = createBrowserHistory();
+const browserHistoryWithBaseName = createBrowserHistory({ basename: '/basename-prefix' });
 
 function TestComponent() {
 	return <div>Test!</div>;
@@ -45,6 +46,19 @@ describe('Router (jsx)', () => {
 		document.body.removeChild(container);
 	});
 
+	describe('#historyWithBaseName', () => {
+		it('should render the child and inherit parent (partial URL) with basename `/basename-prefix`', () => {
+			render(
+				<Router url={ '/foo/bar' } history={ browserHistoryWithBaseName }>
+					<Route path={ '/foo' } component={ ({ children }) => <div><p>Parent Component</p>{ children }</div> }>
+		 				<Route path={ '/:test' } component={ ({ params }) => <div>Child is { params.test } Link is <Link to="/foo/test" /></div> } />
+					</Route>				
+				</Router>,
+				container
+			);
+			expect(container.innerHTML).to.equal(innerHTML('<div><p>Parent Component</p><div>Child is bar Link is <a href="/basename-prefix/foo/test"></a></div></div>'));
+		});
+	});
 	describe('#history', () => {
 		it('should render the parent component only', () => {
 			render(

--- a/packages/inferno-router/__tests__/router.spec.jsx
+++ b/packages/inferno-router/__tests__/router.spec.jsx
@@ -51,8 +51,8 @@ describe('Router (jsx)', () => {
 			render(
 				<Router url={ '/foo/bar' } history={ browserHistoryWithBaseName }>
 					<Route path={ '/foo' } component={ ({ children }) => <div><p>Parent Component</p>{ children }</div> }>
-		 				<Route path={ '/:test' } component={ ({ params }) => <div>Child is { params.test } Link is <Link to="/foo/test" /></div> } />
-					</Route>				
+						<Route path={ '/:test' } component={ ({ params }) => <div>Child is { params.test } Link is <Link to="/foo/test" /></div> } />
+					</Route>
 				</Router>,
 				container
 			);

--- a/packages/inferno-router/src/Link.ts
+++ b/packages/inferno-router/src/Link.ts
@@ -15,7 +15,7 @@ export default function Link(props, { router }): VNode {
 	// TODO: Convert to object assign
 	const { activeClassName, activeStyle, className, onClick, to, ...otherProps } = props;
 	const elemProps: ILinkProps = {
-		href: isBrowser ? router.createHref({pathname: to}) : router.location.baseUrl ? router.location.baseUrl + to : to
+		href: isBrowser ? router.createHref({pathname: to}) : router.location.baseUrl ? router.location.baseUrl + to : to,
 		...otherProps
 	};
 

--- a/packages/inferno-router/src/Link.ts
+++ b/packages/inferno-router/src/Link.ts
@@ -1,5 +1,6 @@
 import { createVNode, VNode } from 'inferno';
 import VNodeFlags from 'inferno-vnode-flags';
+import { isBrowser } from 'inferno-shared';
 
 interface ILinkProps {
 	href: any;
@@ -14,7 +15,7 @@ export default function Link(props, { router }): VNode {
 	// TODO: Convert to object assign
 	const { activeClassName, activeStyle, className, onClick, to, ...otherProps } = props;
 	const elemProps: ILinkProps = {
-		href: to,
+		href: isBrowser ? router.createHref({pathname: to}) : router.location.baseUrl ? router.location.baseUrl + to : to
 		...otherProps
 	};
 

--- a/packages/inferno-router/src/Router.ts
+++ b/packages/inferno-router/src/Router.ts
@@ -9,6 +9,7 @@ export interface IRouterProps {
 	children?: any;
 	router: any;
 	location: any;
+	baseUrl?: any;
 	component?: Component<any, any>;
 }
 

--- a/packages/inferno-router/src/Router.ts
+++ b/packages/inferno-router/src/Router.ts
@@ -20,6 +20,7 @@ function createrRouter(history) {
 		push: history.push,
 		replace: history.replace,
 		listen: history.listen,
+		createHref: history.createHref,
 		isActive(url) {
 			return matchPath(true, url, this.url);
 		},

--- a/packages/inferno-router/src/RouterContext.ts
+++ b/packages/inferno-router/src/RouterContext.ts
@@ -15,7 +15,8 @@ export default class RouterContext extends Component<IRouterProps, any> {
 		return {
 			router: this.props.router || {
 				location: {
-					pathname: this.props.location
+					pathname: this.props.location,
+					baseUrl: this.props.baseUrl
 				}
 			}
 		};


### PR DESCRIPTION
**Objective**

This PR adds support for basename options for history and ensure that Link component creates correct href url with basename prefix based on history.createHref method in browser and using baseUrl prop on RouterContext for SSR. 
