### PR TITLE
Fixed setStateSync being discarded

### DIFF
--- a/packages/inferno-component/__tests__/state.spec.js
+++ b/packages/inferno-component/__tests__/state.spec.js
@@ -1,0 +1,55 @@
+import { expect } from 'chai';
+import { createVNode, render } from 'inferno';
+import Component from '../dist-es';
+import VNodeFlags from 'inferno-vnode-flags';
+
+let counter = 0;
+
+class TestCWRP extends Component {
+	constructor(props) {
+		super(props);
+
+		this.state = {
+			a: 0,
+			b: 0,
+		};
+	}
+
+	componentWillReceiveProps() {
+		this.setStateSync({ a: 1 });
+
+		if (this.state.a !== 1){
+			this.props.done('state is not correct');
+			return;
+		}
+
+		this.props.done();
+	}
+
+	render() {
+		return <div>{JSON.stringify(this.state)}</div>;
+	}
+}
+
+describe('setting state', () => {
+	let container;
+
+	beforeEach(function () {
+		container = document.createElement('div');
+		document.body.appendChild(container);
+	});
+
+	afterEach(function () {
+		render(null, container);
+		container.innerHTML = '';
+		document.body.removeChild(container);
+	});
+
+	it('setStateSync should apply state during componentWillReceiveProps', (done) => {
+		const node = createVNode(VNodeFlags.ComponentClass, TestCWRP, { done }, null);
+		render(node, container);
+		node.props.foo = 1;
+		render(node, container);
+	});
+
+});

--- a/packages/inferno-component/src/index.ts
+++ b/packages/inferno-component/src/index.ts
@@ -91,7 +91,7 @@ function queueStateChanges<P, S>(component: Component<P, S>, newState, callback:
 			addToQueue(component, false, callback);
 		}
 	} else {
-		component.state = Object.assign(component.state, component._pendingState, newState);
+		Object.assign(component.state, component._pendingState, newState);
 		component._pendingState = {};
 	}
 }

--- a/packages/inferno-component/src/index.ts
+++ b/packages/inferno-component/src/index.ts
@@ -91,7 +91,7 @@ function queueStateChanges<P, S>(component: Component<P, S>, newState, callback:
 			addToQueue(component, false, callback);
 		}
 	} else {
-		component.state = Object.assign({}, component.state, component._pendingState);
+		component.state = Object.assign(component.state, component._pendingState, newState);
 		component._pendingState = {};
 	}
 }

--- a/packages/inferno-component/src/index.ts
+++ b/packages/inferno-component/src/index.ts
@@ -83,7 +83,7 @@ function queueStateChanges<P, S>(component: Component<P, S>, newState, callback:
 	for (let stateKey in newState) {
 		component._pendingState[stateKey] = newState[stateKey];
 	}
-	if (!component._pendingSetState && isBrowser) {
+	if (!component._pendingSetState && isBrowser && !(sync && component._blockRender)) {
 		if (sync || component._blockRender) {
 			component._pendingSetState = true;
 			applyState(component, false, callback);
@@ -91,8 +91,9 @@ function queueStateChanges<P, S>(component: Component<P, S>, newState, callback:
 			addToQueue(component, false, callback);
 		}
 	} else {
-		Object.assign(component.state, component._pendingState, newState);
+		Object.assign(component.state, component._pendingState);
 		component._pendingState = {};
+		component._pendingSetState = false;
 	}
 }
 


### PR DESCRIPTION
**Objective**

This PR fixes the issue where a call to `setStateSync` would be ignored if there was a previous, not-yet-handled call to `setState`. 

In such a scenario, `_component.pendingSetState` would be true on L86, the else condition would be entered, and the pending state would be applied but the contents of `newState` would be lost.