### PR TITLE
Make module distribution build target es5

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -3,5 +3,5 @@
   "packages": [
     "packages/*"
   ],
-  "version": "1.3.0-rc.2"
+  "version": "1.3.0-rc.3"
 }

--- a/packages/inferno-compat/package.json
+++ b/packages/inferno-compat/package.json
@@ -1,6 +1,6 @@
 {
   "name": "inferno-compat",
-  "version": "1.3.0-rc.2",
+  "version": "1.3.0-rc.3",
   "license": "MIT",
   "description": "Provides a compatibility with React codebases",
   "author": {
@@ -23,18 +23,18 @@
     "user interfaces"
   ],
   "dependencies": {
-    "inferno-component": "^1.3.0-rc.2",
-    "inferno-create-class": "^1.3.0-rc.2",
-    "inferno-create-element": "^1.3.0-rc.2",
-    "inferno-shared": "^1.3.0-rc.1",
+    "inferno-component": "^1.3.0-rc.3",
+    "inferno-create-class": "^1.3.0-rc.3",
+    "inferno-create-element": "^1.3.0-rc.3",
+    "inferno-shared": "^1.3.0-rc.3",
     "inferno-transition-group": "1.1.1",
     "inferno-vnode-flags": "^1.3.0-rc.1",
-    "inferno": "^1.3.0-rc.2",
+    "inferno": "^1.3.0-rc.3",
     "proptypes": "0.14.4",
     "rc-css-transition-group-modern": "^2.1.6"
   },
   "devDependencies": {
-    "inferno-hyperscript": "^1.3.0-rc.2"
+    "inferno-hyperscript": "^1.3.0-rc.3"
   },
   "bundledDependencies": [
     "inferno-shared",

--- a/packages/inferno-component/package.json
+++ b/packages/inferno-component/package.json
@@ -1,6 +1,6 @@
 {
   "name": "inferno-component",
-  "version": "1.3.0-rc.2",
+  "version": "1.3.0-rc.3",
   "license": "MIT",
   "description": "Provides ES2015 stateful components (with lifecycle events) to Inferno",
   "author": {
@@ -29,8 +29,8 @@
     "rollup"
   ],
   "dependencies": {
-    "inferno": "^1.3.0-rc.2",
-    "inferno-shared": "^1.3.0-rc.1",
+    "inferno": "^1.3.0-rc.3",
+    "inferno-shared": "^1.3.0-rc.3",
     "inferno-vnode-flags": "^1.3.0-rc.1"
   },
   "bundledDependencies": [

--- a/packages/inferno-create-class/package.json
+++ b/packages/inferno-create-class/package.json
@@ -1,6 +1,6 @@
 {
   "name": "inferno-create-class",
-  "version": "1.3.0-rc.2",
+  "version": "1.3.0-rc.3",
   "license": "MIT",
   "description": "Provides a helper to create Inferno Components without needing ES2015",
   "author": {
@@ -23,12 +23,12 @@
     "user interfaces"
   ],
   "dependencies": {
-    "inferno-shared": "^1.3.0-rc.1",
-    "inferno-component": "^1.3.0-rc.2"
+    "inferno-shared": "^1.3.0-rc.3",
+    "inferno-component": "^1.3.0-rc.3"
   },
   "devDependencies": {
-    "inferno": "^1.3.0-rc.2",
-    "inferno-create-element": "^1.3.0-rc.2"
+    "inferno": "^1.3.0-rc.3",
+    "inferno-create-element": "^1.3.0-rc.3"
   },
   "bundledDependencies": [
     "inferno-shared"

--- a/packages/inferno-create-element/package.json
+++ b/packages/inferno-create-element/package.json
@@ -1,6 +1,6 @@
 {
   "name": "inferno-create-element",
-  "version": "1.3.0-rc.2",
+  "version": "1.3.0-rc.3",
   "license": "MIT",
   "description": "Provides methods to create Inferno VNodes",
   "author": {
@@ -23,10 +23,10 @@
     "user interfaces"
   ],
   "dependencies": {
-    "inferno": "^1.3.0-rc.2",
-    "inferno-shared": "^1.3.0-rc.1",
+    "inferno": "^1.3.0-rc.3",
+    "inferno-shared": "^1.3.0-rc.3",
     "inferno-vnode-flags": "^1.3.0-rc.1",
-    "inferno-component": "^1.3.0-rc.2"
+    "inferno-component": "^1.3.0-rc.3"
   },
   "bundledDependencies": [
     "inferno-shared",

--- a/packages/inferno-devtools/package.json
+++ b/packages/inferno-devtools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "inferno-devtools",
-  "version": "1.3.0-rc.2",
+  "version": "1.3.0-rc.3",
   "license": "MIT",
   "description": "Provides support for React's Dev Tools for Inferno",
   "author": {
@@ -24,9 +24,9 @@
   ],
   "repository": "https://github.com/infernojs/inferno",
   "dependencies": {
-    "inferno": "^1.3.0-rc.2",
-    "inferno-component": "^1.3.0-rc.2",
-    "inferno-shared": "^1.3.0-rc.1",
+    "inferno": "^1.3.0-rc.3",
+    "inferno-component": "^1.3.0-rc.3",
+    "inferno-shared": "^1.3.0-rc.3",
     "inferno-vnode-flags": "^1.3.0-rc.1"
   },
   "bundledDependencies": [

--- a/packages/inferno-hyperscript/package.json
+++ b/packages/inferno-hyperscript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "inferno-hyperscript",
-  "version": "1.3.0-rc.2",
+  "version": "1.3.0-rc.3",
   "license": "MIT",
   "description": "Bridging hyperscript to InfernoJS",
   "author": "Terin Stock <terinjokes@gmail.com> (https://terinstock.com/)",
@@ -17,8 +17,8 @@
   ],
   "repository": "https://github.com/infernojs/inferno",
   "dependencies": {
-    "inferno": "^1.3.0-rc.2",
-    "inferno-shared": "^1.3.0-rc.1",
+    "inferno": "^1.3.0-rc.3",
+    "inferno-shared": "^1.3.0-rc.3",
     "inferno-vnode-flags": "^1.3.0-rc.1"
   },
   "bundledDependencies": [

--- a/packages/inferno-mobx/package.json
+++ b/packages/inferno-mobx/package.json
@@ -1,6 +1,6 @@
 {
   "name": "inferno-mobx",
-  "version": "1.3.0-rc.2",
+  "version": "1.3.0-rc.3",
   "license": "MIT",
   "description": "Official Inferno bindings for Mobx",
   "author": {
@@ -27,11 +27,11 @@
   "repository": "https://github.com/infernojs/inferno",
   "dependencies": {
     "hoist-non-inferno-statics": "^1.1.3",
-    "inferno": "^1.3.0-rc.2",
-    "inferno-component": "^1.3.0-rc.2",
-    "inferno-create-class": "^1.3.0-rc.2",
-    "inferno-create-element": "^1.3.0-rc.2",
-    "inferno-shared": "^1.3.0-rc.1",
+    "inferno": "^1.3.0-rc.3",
+    "inferno-component": "^1.3.0-rc.3",
+    "inferno-create-class": "^1.3.0-rc.3",
+    "inferno-create-element": "^1.3.0-rc.3",
+    "inferno-shared": "^1.3.0-rc.3",
     "mobx": "*"
   },
   "bundledDependencies": [

--- a/packages/inferno-redux/package.json
+++ b/packages/inferno-redux/package.json
@@ -1,6 +1,6 @@
 {
   "name": "inferno-redux",
-  "version": "1.3.0-rc.2",
+  "version": "1.3.0-rc.3",
   "license": "MIT",
   "description": "Official Inferno bindings for Redux",
   "author": {
@@ -26,14 +26,14 @@
   "repository": "https://github.com/infernojs/inferno",
   "dependencies": {
     "hoist-non-inferno-statics": "^1.1.3",
-    "inferno": "^1.3.0-rc.2",
-    "inferno-component": "^1.3.0-rc.2",
-    "inferno-create-element": "^1.3.0-rc.2",
-    "inferno-shared": "^1.3.0-rc.1",
+    "inferno": "^1.3.0-rc.3",
+    "inferno-component": "^1.3.0-rc.3",
+    "inferno-create-element": "^1.3.0-rc.3",
+    "inferno-shared": "^1.3.0-rc.3",
     "redux": "*"
   },
   "devDependencies": {
-    "inferno-router": "^1.3.0-rc.2"
+    "inferno-router": "^1.3.0-rc.3"
   },
   "bundledDependencies": [
     "inferno-shared"

--- a/packages/inferno-router/README.md
+++ b/packages/inferno-router/README.md
@@ -29,7 +29,7 @@ npm install inferno-router
 ```js
 import Inferno from 'inferno';
 import { Router, Route, IndexRoute } from 'inferno-router';
-import { createBrowserHistory } from 'history';
+import createBrowserHistory from 'history/createBrowserHistory';
 
 const browserHistory = createBrowserHistory();
 

--- a/packages/inferno-router/__tests__/router.spec.jsx
+++ b/packages/inferno-router/__tests__/router.spec.jsx
@@ -1,12 +1,13 @@
 import {
 	expect
 } from 'chai';
-import createMemoryHistory from 'history/createMemoryHistory';
+import { createMemoryHistory, createBrowserHistory } from 'history';
 import { cloneVNode, render } from 'inferno';
 import { innerHTML } from 'inferno/test/utils';
-import { IndexRoute, Route, Router, RouterContext } from '../dist-es';
+import { IndexRoute, Route, Router, RouterContext, Link } from '../dist-es';
 
-const browserHistory = createMemoryHistory();
+const browserHistory = createBrowserHistory();
+const browserHistoryWithBaseName = createBrowserHistory({ basename: '/basename-prefix' });
 
 function TestComponent() {
 	return <div>Test!</div>;
@@ -45,6 +46,19 @@ describe('Router (jsx)', () => {
 		document.body.removeChild(container);
 	});
 
+	describe('#historyWithBaseName', () => {
+		it('should render the child and inherit parent (partial URL) with basename `/basename-prefix`', () => {
+			render(
+				<Router url={ '/foo/bar' } history={ browserHistoryWithBaseName }>
+					<Route path={ '/foo' } component={ ({ children }) => <div><p>Parent Component</p>{ children }</div> }>
+						<Route path={ '/:test' } component={ ({ params }) => <div>Child is { params.test } Link is <Link to="/foo/test" /></div> } />
+					</Route>
+				</Router>,
+				container
+			);
+			expect(container.innerHTML).to.equal(innerHTML('<div><p>Parent Component</p><div>Child is bar Link is <a href="/basename-prefix/foo/test"></a></div></div>'));
+		});
+	});
 	describe('#history', () => {
 		it('should render the parent component only', () => {
 			render(

--- a/packages/inferno-router/package.json
+++ b/packages/inferno-router/package.json
@@ -1,6 +1,6 @@
 {
   "name": "inferno-router",
-  "version": "1.3.0-rc.2",
+  "version": "1.3.0-rc.3",
   "license": "MIT",
   "description": "Provides routing functionality for Inferno",
   "author": {
@@ -25,10 +25,10 @@
   ],
   "repository": "https://github.com/infernojs/inferno",
   "dependencies": {
-    "inferno": "^1.3.0-rc.2",
-    "inferno-component": "^1.3.0-rc.2",
-    "inferno-create-element": "^1.3.0-rc.2",
-    "inferno-shared": "^1.3.0-rc.1",
+    "inferno": "^1.3.0-rc.3",
+    "inferno-component": "^1.3.0-rc.3",
+    "inferno-create-element": "^1.3.0-rc.3",
+    "inferno-shared": "^1.3.0-rc.3",
     "inferno-vnode-flags": "^1.3.0-rc.1",
     "path-to-regexp-es6": "0.0.2"
   },

--- a/packages/inferno-router/src/Link.ts
+++ b/packages/inferno-router/src/Link.ts
@@ -1,5 +1,6 @@
 import { createVNode, VNode } from 'inferno';
 import VNodeFlags from 'inferno-vnode-flags';
+import { isBrowser } from 'inferno-shared';
 
 interface ILinkProps {
 	href: any;
@@ -14,7 +15,7 @@ export default function Link(props, { router }): VNode {
 	// TODO: Convert to object assign
 	const { activeClassName, activeStyle, className, onClick, to, ...otherProps } = props;
 	const elemProps: ILinkProps = {
-		href: to,
+		href: isBrowser ? router.createHref({pathname: to}) : router.location.baseUrl ? router.location.baseUrl + to : to,
 		...otherProps
 	};
 

--- a/packages/inferno-router/src/Router.ts
+++ b/packages/inferno-router/src/Router.ts
@@ -9,6 +9,7 @@ export interface IRouterProps {
 	children?: any;
 	router: any;
 	location: any;
+	baseUrl?: any;
 	component?: Component<any, any>;
 }
 
@@ -20,6 +21,7 @@ function createrRouter(history) {
 		push: history.push,
 		replace: history.replace,
 		listen: history.listen,
+		createHref: history.createHref,
 		isActive(url) {
 			return matchPath(true, url, this.url);
 		},

--- a/packages/inferno-router/src/RouterContext.ts
+++ b/packages/inferno-router/src/RouterContext.ts
@@ -15,7 +15,8 @@ export default class RouterContext extends Component<IRouterProps, any> {
 		return {
 			router: this.props.router || {
 				location: {
-					pathname: this.props.location
+					pathname: this.props.location,
+					baseUrl: this.props.baseUrl
 				}
 			}
 		};

--- a/packages/inferno-server/package.json
+++ b/packages/inferno-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "inferno-server",
-  "version": "1.3.0-rc.2",
+  "version": "1.3.0-rc.3",
   "license": "MIT",
   "description": "Provides methods to render HTML strings from Inferno elements",
   "author": {
@@ -30,14 +30,14 @@
   "typings": "dist-es/index.d.ts",
   "repository": "https://github.com/infernojs/inferno",
   "dependencies": {
-    "inferno": "^1.3.0-rc.2",
-    "inferno-shared": "^1.3.0-rc.1",
+    "inferno": "^1.3.0-rc.3",
+    "inferno-shared": "^1.3.0-rc.3",
     "inferno-vnode-flags": "^1.3.0-rc.1"
   },
   "devDependencies": {
-    "inferno-component": "^1.3.0-rc.2",
-    "inferno-create-element": "^1.3.0-rc.2",
-    "inferno-create-class": "^1.3.0-rc.2"
+    "inferno-component": "^1.3.0-rc.3",
+    "inferno-create-element": "^1.3.0-rc.3",
+    "inferno-create-class": "^1.3.0-rc.3"
   },
   "bundledDependencies": [
     "inferno-shared",

--- a/packages/inferno-shared/package.json
+++ b/packages/inferno-shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "inferno-shared",
-  "version": "1.3.0-rc.1",
+  "version": "1.3.0-rc.3",
   "license": "MIT",
   "description": "Helpers functions for Inferno",
   "author": {

--- a/packages/inferno-test-utils/package.json
+++ b/packages/inferno-test-utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "inferno-test-utils",
-  "version": "1.3.0-rc.2",
+  "version": "1.3.0-rc.3",
   "license": "MIT",
   "description": "Suite of utilities for testing Inferno applications",
   "author": {
@@ -21,15 +21,15 @@
     "utils"
   ],
   "dependencies": {
-    "inferno": "^1.3.0-rc.2",
-    "inferno-create-class": "^1.3.0-rc.2",
-    "inferno-create-element": "^1.3.0-rc.2",
-    "inferno-shared": "^1.3.0-rc.1",
+    "inferno": "^1.3.0-rc.3",
+    "inferno-create-class": "^1.3.0-rc.3",
+    "inferno-create-element": "^1.3.0-rc.3",
+    "inferno-shared": "^1.3.0-rc.3",
     "inferno-vnode-flags": "^1.3.0-rc.1"
   },
   "devDependencies": {
-    "inferno-component": "^1.3.0-rc.2",
-    "inferno-server": "^1.3.0-rc.2"
+    "inferno-component": "^1.3.0-rc.3",
+    "inferno-server": "^1.3.0-rc.3"
   },
   "bundledDependencies": [
     "inferno-shared",

--- a/packages/inferno/package.json
+++ b/packages/inferno/package.json
@@ -1,6 +1,6 @@
 {
   "name": "inferno",
-  "version": "1.3.0-rc.2",
+  "version": "1.3.0-rc.3",
   "license": "MIT",
   "description": "An extremely fast, React-like JavaScript library for building modern user interfaces",
   "author": {
@@ -34,7 +34,7 @@
   "typings": "dist-es/index.d.ts",
   "repository": "https://github.com/infernojs/inferno",
   "dependencies": {
-    "inferno-shared": "^1.3.0-rc.1",
+    "inferno-shared": "^1.3.0-rc.3",
     "inferno-vnode-flags": "^1.3.0-rc.1"
   },
   "bundledDependencies": [

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,7 @@
 	"version": "2.1.4",
 	"compilerOptions": {
 		"baseUrl": ".",
-		"target": "es6",
+		"target": "es5",
 		"module": "es6",
 		"allowJs": false,
 		"moduleResolution": "node",


### PR DESCRIPTION
 *Before* submitting a PR please:
 - Make sure you have based your branch off the [dev branch](https://github.com/infernojs/inferno/tree/dev).
 - Submit your PR against the [dev branch](https://github.com/infernojs/inferno/tree/dev).
 - Run `npm run build` and check that the build succeeds.
 - Ensure that the PR hasn't been submitted before.

---

## PR Template

**Objective**

This PR changes `module`(dist-es) distribution build to target **es5** using **es6 module** syntax. 
The output file size will increase slightly, but not noticeably.

**Closes Issue**

It closes #823 
(Tested with webpack v2.2)
