### PR TITLE
add alias to rollup, change module field to jsnext:main

### DIFF
--- a/bin/link
+++ b/bin/link
@@ -9,7 +9,7 @@ const PROJECT_FOLDER = resolve(__dirname, '..');
 rimraf.sync(join(PROJECT_FOLDER, 'node_modules', 'inferno'));
 rimraf.sync(join(PROJECT_FOLDER, 'node_modules', 'inferno-vnode-flags'));
 
-const cwd = process.cwd()
+const cwd = process.cwd();
 
 ensureSymlinkSync(join(PROJECT_FOLDER, 'tsconfig.json'), join(cwd, 'tsconfig.json'));
 ensureSymlinkSync(join(PROJECT_FOLDER, '.npmignore'), join(cwd, '.npmignore'));

--- a/bin/rollup
+++ b/bin/rollup
@@ -6,6 +6,7 @@ const buble = require('rollup-plugin-buble');
 const replace = require('rollup-plugin-replace');
 const uglify = require('rollup-plugin-uglify');
 const filesize = require('rollup-plugin-filesize');
+const alias = require('rollup-plugin-alias');
 
 const nodeResolve = require('rollup-plugin-node-resolve');
 const commonjs = require('rollup-plugin-commonjs');
@@ -15,7 +16,67 @@ const rootPackageJson = require(join(PROJECT_FOLDER, 'package.json'));
 
 const { NODE_ENV } = process.env;
 
+const COPYRIGHT_YEAR = new Date().getFullYear();
+
+const cwd = process.cwd();
+const pkgJson = require(join(cwd, 'package.json'));
+
+const {
+	name,
+	version,
+	dependencies = {},
+	'jsnext:main': entryFile,
+	rollup: rollupConfig = {},
+	bundledDependencies = {}
+} = pkgJson;
+
+const copyright = `
+/*!
+ * ${rollupConfig.moduleName || name} v${version}
+ * (c) ${COPYRIGHT_YEAR} ${rootPackageJson.author.name}'
+ * Released under the ${rootPackageJson.license} License.
+ */
+`;
+
+const entry = require.resolve(resolve(cwd, entryFile));
+let filename = name;
+if (NODE_ENV === 'production') {
+	filename += '.min.js';
+} else if (NODE_ENV === 'development') {
+	filename += '.node.js';
+} else {
+	filename += '.js';
+}
+const dest = join(cwd, 'dist', filename);
+const bundleConfig = {
+	dest,
+	format: 'umd',
+	moduleName: rollupConfig.moduleName || name,
+	globals: Object.assign({ moduleGlobal: rollupConfig.moduleGlobal }, rollupConfig.moduleGlobals),
+	banner: copyright,
+	sourceMap: false
+};
+
+const external = Object.keys(dependencies).filter(n => !bundledDependencies.includes(n));
+
 const plugins = [
+	alias({
+		'inferno-compat': resolve(__dirname, '../packages/inferno-compat/dist-es/index'),
+		'inferno-component': resolve(__dirname, '../packages/inferno-component/dist-es/index'),
+		'inferno-create-class': resolve(__dirname, '../packages/inferno-create-class/dist-es/index'),
+		'inferno-create-element': resolve(__dirname, '../packages/inferno-create-element/dist-es/index'),
+		'inferno-shared': resolve(__dirname, '../packages/inferno-shared/dist-es/index'),
+		'inferno-hyperscript': resolve(__dirname, '../packages/inferno-hyperscript/dist-es/index'),
+		'inferno-mobx': resolve(__dirname, '../packages/inferno-mobx/dist-es/index'),
+		'inferno-redux': resolve(__dirname, '../packages/inferno-redux/dist-es/index'),
+		'inferno-router': resolve(__dirname, '../packages/inferno-router/dist-es/index'),
+		'inferno-server': resolve(__dirname, '../packages/inferno-server/dist-es/index'),
+		inferno: resolve(__dirname, '../packages/inferno/dist-es/index')
+	}),
+	nodeResolve({
+		jsnext: true,
+		skip: external
+	}),
 	commonjs({
 		include: 'node_modules/**'
 	}),
@@ -64,62 +125,9 @@ if (NODE_ENV === 'production') {
 // Filesize plugin needs to be last to report correct filesizes when minified
 plugins.push(filesize());
 
-const COPYRIGHT_YEAR = new Date().getFullYear();
-
-function withNodeResolve(arr, resolveConfig) {
-	const newArray = Array.from(arr);
-	const index = newArray.findIndex(plugin => plugin.name === 'buble');
-	newArray.splice(index, 0, nodeResolve(resolveConfig));
-	return newArray;
-}
-
-const cwd = process.cwd();
-const pkgJson = require(join(cwd, 'package.json'));
-
-const {
-	name,
-	version,
-	dependencies = {},
-	module: entryFile,
-	rollup: rollupConfig = {},
-	bundledDependencies = {}
-} = pkgJson;
-
-const copyright = `
-/*!
- * ${name} v${version}
- * (c) ${COPYRIGHT_YEAR} ${rootPackageJson.author.name}'
- * Released under the ${rootPackageJson.license} License.
- */
-`;
-
-const entry = require.resolve(resolve(cwd, entryFile));
-let filename = name;
-if (NODE_ENV === 'production') {
-	filename += '.min.js';
-} else if (NODE_ENV === 'development') {
-	filename += '.node.js';
-} else {
-	filename += '.js';
-}
-const dest = join(cwd, 'dist', filename);
-const bundleConfig = {
-	dest,
-	format: 'umd',
-	moduleName: rollupConfig.moduleName || name,
-	globals: Object.assign({ moduleGlobal: rollupConfig.moduleGlobal }, rollupConfig.moduleGlobals),
-	banner: copyright,
-	sourceMap: false
-};
-
-const external = Object.keys(dependencies).filter(n => !bundledDependencies.includes(n));
-
 rollup({
 	entry,
-	plugins: withNodeResolve(plugins, {
-		jsnext: true,
-		skip: external
-	}),
+	plugins,
 	external
 })
 .then(({ write }) => write(bundleConfig)).catch(console.error);

--- a/package.json
+++ b/package.json
@@ -80,6 +80,7 @@
     "redux": "^3.6.0",
     "rimraf": "^2.5.4",
     "rollup": "0.41.4",
+    "rollup-plugin-alias": "^1.2.0",
     "rollup-plugin-babel": "^2.7.1",
     "rollup-plugin-buble": "^0.15.0",
     "rollup-plugin-commonjs": "^7.0.0",

--- a/packages/inferno-compat/package.json
+++ b/packages/inferno-compat/package.json
@@ -12,7 +12,7 @@
   },
   "homepage": "https://github.com/infernojs/inferno#readme",
   "main": "dist/inferno-compat.node.js",
-  "module": "dist-es/index.js",
+  "jsnext:main": "dist-es/index.js",
   "typings": "dist-es/index.d.ts",
   "keywords": [
     "babel",

--- a/packages/inferno-compat/package.json
+++ b/packages/inferno-compat/package.json
@@ -13,6 +13,7 @@
   "homepage": "https://github.com/infernojs/inferno#readme",
   "main": "dist/inferno-compat.node.js",
   "jsnext:main": "dist-es/index.js",
+  "module": "dist-es/index.js",
   "typings": "dist-es/index.d.ts",
   "keywords": [
     "babel",

--- a/packages/inferno-component/package.json
+++ b/packages/inferno-component/package.json
@@ -13,6 +13,7 @@
   "homepage": "https://github.com/infernojs/inferno#readme",
   "main": "dist/inferno-component.node.js",
   "jsnext:main": "dist-es/index.js",
+  "module": "dist-es/index.js",
   "typings": "dist-es/index.d.ts",
   "keywords": [
     "babel",

--- a/packages/inferno-component/package.json
+++ b/packages/inferno-component/package.json
@@ -12,7 +12,7 @@
   },
   "homepage": "https://github.com/infernojs/inferno#readme",
   "main": "dist/inferno-component.node.js",
-  "module": "dist-es/index.js",
+  "jsnext:main": "dist-es/index.js",
   "typings": "dist-es/index.d.ts",
   "keywords": [
     "babel",

--- a/packages/inferno-create-class/package.json
+++ b/packages/inferno-create-class/package.json
@@ -13,6 +13,7 @@
   "homepage": "https://github.com/infernojs/inferno#readme",
   "main": "dist/inferno-create-class.node.js",
   "jsnext:main": "dist-es/index.js",
+  "module": "dist-es/index.js",
   "typings": "dist-es/index.d.ts",
   "keywords": [
     "babel",

--- a/packages/inferno-create-class/package.json
+++ b/packages/inferno-create-class/package.json
@@ -12,7 +12,7 @@
   },
   "homepage": "https://github.com/infernojs/inferno#readme",
   "main": "dist/inferno-create-class.node.js",
-  "module": "dist-es/index.js",
+  "jsnext:main": "dist-es/index.js",
   "typings": "dist-es/index.d.ts",
   "keywords": [
     "babel",

--- a/packages/inferno-create-element/package.json
+++ b/packages/inferno-create-element/package.json
@@ -13,6 +13,7 @@
   "homepage": "https://github.com/infernojs/inferno#readme",
   "main": "dist/inferno-create-element.node.js",
   "jsnext:main": "dist-es/index.js",
+  "module": "dist-es/index.js",
   "typings": "dist-es/index.d.ts",
   "keywords": [
     "babel",

--- a/packages/inferno-create-element/package.json
+++ b/packages/inferno-create-element/package.json
@@ -12,7 +12,7 @@
   },
   "homepage": "https://github.com/infernojs/inferno#readme",
   "main": "dist/inferno-create-element.node.js",
-  "module": "dist-es/index.js",
+  "jsnext:main": "dist-es/index.js",
   "typings": "dist-es/index.d.ts",
   "keywords": [
     "babel",

--- a/packages/inferno-devtools/package.json
+++ b/packages/inferno-devtools/package.json
@@ -12,7 +12,7 @@
   },
   "homepage": "https://github.com/infernojs/inferno#readme",
   "main": "dist/inferno-devtools.js",
-  "module": "dist-es/index.js",
+  "jsnext:main": "dist-es/index.js",
   "typings": "dist-es/index.d.ts",
   "keywords": [
     "babel",

--- a/packages/inferno-devtools/package.json
+++ b/packages/inferno-devtools/package.json
@@ -13,6 +13,7 @@
   "homepage": "https://github.com/infernojs/inferno#readme",
   "main": "dist/inferno-devtools.js",
   "jsnext:main": "dist-es/index.js",
+  "module": "dist-es/index.js",
   "typings": "dist-es/index.d.ts",
   "keywords": [
     "babel",

--- a/packages/inferno-hyperscript/package.json
+++ b/packages/inferno-hyperscript/package.json
@@ -9,7 +9,7 @@
   },
   "homepage": "https://github.com/infernojs/inferno#readme",
   "main": "dist/inferno-hyperscript.node.js",
-  "module": "dist-es/index.js",
+  "jsnext:main": "dist-es/index.js",
   "typings": "dist-es/index.d.ts",
   "keywords": [
     "inferno",

--- a/packages/inferno-hyperscript/package.json
+++ b/packages/inferno-hyperscript/package.json
@@ -10,6 +10,7 @@
   "homepage": "https://github.com/infernojs/inferno#readme",
   "main": "dist/inferno-hyperscript.node.js",
   "jsnext:main": "dist-es/index.js",
+  "module": "dist-es/index.js",
   "typings": "dist-es/index.d.ts",
   "keywords": [
     "inferno",

--- a/packages/inferno-mobx/package.json
+++ b/packages/inferno-mobx/package.json
@@ -12,7 +12,7 @@
   },
   "homepage": "https://github.com/infernojs/inferno#readme",
   "main": "dist/inferno-mobx.node.js",
-  "module": "dist-es/index.js",
+  "jsnext:main": "dist-es/index.js",
   "typings": "dist-es/index.d.ts",
   "keywords": [
     "babel",

--- a/packages/inferno-mobx/package.json
+++ b/packages/inferno-mobx/package.json
@@ -13,6 +13,7 @@
   "homepage": "https://github.com/infernojs/inferno#readme",
   "main": "dist/inferno-mobx.node.js",
   "jsnext:main": "dist-es/index.js",
+  "module": "dist-es/index.js",
   "typings": "dist-es/index.d.ts",
   "keywords": [
     "babel",

--- a/packages/inferno-redux/package.json
+++ b/packages/inferno-redux/package.json
@@ -12,7 +12,7 @@
   },
   "homepage": "https://github.com/infernojs/inferno#readme",
   "main": "dist/inferno-redux.node.js",
-  "module": "dist-es/index.js",
+  "jsnext:main": "dist-es/index.js",
   "typings": "dist-es/index.d.ts",
   "keywords": [
     "babel",

--- a/packages/inferno-redux/package.json
+++ b/packages/inferno-redux/package.json
@@ -13,6 +13,7 @@
   "homepage": "https://github.com/infernojs/inferno#readme",
   "main": "dist/inferno-redux.node.js",
   "jsnext:main": "dist-es/index.js",
+  "module": "dist-es/index.js",
   "typings": "dist-es/index.d.ts",
   "keywords": [
     "babel",

--- a/packages/inferno-router/package.json
+++ b/packages/inferno-router/package.json
@@ -13,6 +13,7 @@
   "homepage": "https://github.com/infernojs/inferno#readme",
   "main": "dist/inferno-router.node.js",
   "jsnext:main": "dist-es/index.js",
+  "module": "dist-es/index.js",
   "typings": "dist-es/index.d.ts",
   "keywords": [
     "babel",

--- a/packages/inferno-router/package.json
+++ b/packages/inferno-router/package.json
@@ -12,7 +12,7 @@
   },
   "homepage": "https://github.com/infernojs/inferno#readme",
   "main": "dist/inferno-router.node.js",
-  "module": "dist-es/index.js",
+  "jsnext:main": "dist-es/index.js",
   "typings": "dist-es/index.d.ts",
   "keywords": [
     "babel",

--- a/packages/inferno-server/package.json
+++ b/packages/inferno-server/package.json
@@ -27,6 +27,7 @@
   ],
   "main": "dist/inferno-server.node.js",
   "jsnext:main": "dist-es/index.js",
+  "module": "dist-es/index.js",
   "typings": "dist-es/index.d.ts",
   "repository": "https://github.com/infernojs/inferno",
   "dependencies": {

--- a/packages/inferno-server/package.json
+++ b/packages/inferno-server/package.json
@@ -26,7 +26,7 @@
     "rollup"
   ],
   "main": "dist/inferno-server.node.js",
-  "module": "dist-es/index.js",
+  "jsnext:main": "dist-es/index.js",
   "typings": "dist-es/index.d.ts",
   "repository": "https://github.com/infernojs/inferno",
   "dependencies": {

--- a/packages/inferno-shared/package.json
+++ b/packages/inferno-shared/package.json
@@ -12,7 +12,7 @@
   },
   "homepage": "https://github.com/infernojs/inferno#readme",
   "main": "dist/inferno-shared.node.js",
-  "module": "dist-es/index.js",
+  "jsnext:main": "dist-es/index.js",
   "typings": "dist-es/index.d.ts",
   "keywords": [
     "inferno",

--- a/packages/inferno-shared/package.json
+++ b/packages/inferno-shared/package.json
@@ -13,6 +13,7 @@
   "homepage": "https://github.com/infernojs/inferno#readme",
   "main": "dist/inferno-shared.node.js",
   "jsnext:main": "dist-es/index.js",
+  "module": "dist-es/index.js",
   "typings": "dist-es/index.d.ts",
   "keywords": [
     "inferno",

--- a/packages/inferno-test-utils/package.json
+++ b/packages/inferno-test-utils/package.json
@@ -44,6 +44,7 @@
   },
   "main": "dist/inferno-test-utils.node.js",
   "jsnext:main": "dist-es/index.js",
+  "module": "dist-es/index.js",
   "typings": "dist-es/index.d.ts",
   "repository": "https://github.com/infernojs/inferno"
 }

--- a/packages/inferno-test-utils/package.json
+++ b/packages/inferno-test-utils/package.json
@@ -43,7 +43,7 @@
     }
   },
   "main": "dist/inferno-test-utils.node.js",
-  "module": "dist-es/index.js",
+  "jsnext:main": "dist-es/index.js",
   "typings": "dist-es/index.d.ts",
   "repository": "https://github.com/infernojs/inferno"
 }

--- a/packages/inferno-vnode-flags/package.json
+++ b/packages/inferno-vnode-flags/package.json
@@ -32,7 +32,7 @@
     "moduleGlobal": "Inferno.VNodeFlags"
   },
   "main": "dist/inferno-vnode-flags.node.js",
-  "module": "dist-es/index.js",
+  "jsnext:main": "dist-es/index.js",
   "typings": "dist-es/index.d.ts",
   "repository": "https://github.com/infernojs/inferno"
 }

--- a/packages/inferno-vnode-flags/package.json
+++ b/packages/inferno-vnode-flags/package.json
@@ -33,6 +33,7 @@
   },
   "main": "dist/inferno-vnode-flags.node.js",
   "jsnext:main": "dist-es/index.js",
+  "module": "dist-es/index.js",
   "typings": "dist-es/index.d.ts",
   "repository": "https://github.com/infernojs/inferno"
 }

--- a/packages/inferno/package.json
+++ b/packages/inferno/package.json
@@ -30,7 +30,7 @@
     "moduleGlobal": "Inferno"
   },
   "main": "dist/inferno.node.js",
-  "module": "dist-es/index.js",
+  "jsnext:main": "dist-es/index.js",
   "typings": "dist-es/index.d.ts",
   "repository": "https://github.com/infernojs/inferno",
   "dependencies": {

--- a/packages/inferno/package.json
+++ b/packages/inferno/package.json
@@ -31,6 +31,7 @@
   },
   "main": "dist/inferno.node.js",
   "jsnext:main": "dist-es/index.js",
+  "module": "dist-es/index.js",
   "typings": "dist-es/index.d.ts",
   "repository": "https://github.com/infernojs/inferno",
   "dependencies": {


### PR DESCRIPTION
 *Before* submitting a PR please:
 - Make sure you have based your branch off the [dev branch](https://github.com/infernojs/inferno/tree/dev).
 - Submit your PR against the [dev branch](https://github.com/infernojs/inferno/tree/dev).
 - Run `npm run build` and check that the build succeeds.
 - Ensure that the PR hasn't been submitted before.

---

## PR Template

**Objective**

This PR adds aliases to rollup config to prevent dupe inferno-shared inline functions, also change `module` to `jsnext:main`

**Closes Issue**

closes #825, #823, #824
