### PR TITLE
Relax isVNode in test utils to allow trees with rendered text

### DIFF
--- a/packages/inferno-test-utils/__tests__/testUtils.spec.browser.jsx
+++ b/packages/inferno-test-utils/__tests__/testUtils.spec.browser.jsx
@@ -398,6 +398,23 @@ describe('Test Utils', () => {
 			findAllInRenderedTree(tree, ({ type }) => types.push(type));
 			expect(types).to.eql([ 'section', FunctionalComponent, 'div' ]);
 		});
+
+		it('should correctly find within a rendered tree with interpolated text', () => {
+			function Hello({ who }) {
+				return (<div>Hello, {who}!</div>);
+			}
+			const predicate = sinon.spy();
+			const treeWithText = renderIntoDocument(<Hello who='world' />);
+			assert.notCalled(predicate);
+			findAllInRenderedTree(treeWithText, predicate);
+
+			assert.callCount(predicate, 5);
+			assert.calledWithMatch(predicate, { type: Hello });
+			assert.calledWithMatch(predicate, { type: 'div' });
+			assert.calledWithMatch(predicate, { children: 'Hello, ' });
+			assert.calledWithMatch(predicate, { children: 'world' });
+			assert.calledWithMatch(predicate, { children: '!' });
+		});
 	});
 
 	describe('findAllInVNodeTree', () => {

--- a/packages/inferno-test-utils/src/index.ts
+++ b/packages/inferno-test-utils/src/index.ts
@@ -19,8 +19,7 @@ import {
 // Type Checkers
 
 export function isVNode(inst: any): boolean {
-	return Boolean(inst) && isObject(inst) && isNumber(inst.flags) &&
-		(inst.flags & (VNodeFlags.Component | VNodeFlags.Element)) > 0;
+	return Boolean(inst) && isObject(inst) && isNumber(inst.flags) && !!inst.flags;
 }
 
 export function isVNodeOfType(inst: VNode, type: string | Function): boolean {


### PR DESCRIPTION
**Objective**

I was attempting to use the `inferno-test-utils` to do some basic testing of a component which renders out "Hello, world!" but got an error stating the element should be a VNode. I traced it down to the `isVNode` function in the test utils being much stricter than the `isVNode` function in `inferno` itself so this PR aims to relax the rules in the test utils version of `isVNode` to just check for flags and thus you can scry in trees with text interpolated into it.

It's probably worth looking into whether these can be combined:
https://github.com/infernojs/inferno/blob/master/packages/inferno/src/core/VNodes.ts#L181
https://github.com/infernojs/inferno/blob/master/packages/inferno-test-utils/src/index.ts#L21

Still very new to this library so feedback appreciated 😸 