### PR TITLE
Remove dataset and inline styles on recycle

### DIFF
--- a/packages/inferno/src/DOM/patching.ts
+++ b/packages/inferno/src/DOM/patching.ts
@@ -153,6 +153,10 @@ export function patchElement(lastVNode: VNode, nextVNode: VNode, parentDom: Node
 		replaceWithNewNode(lastVNode, nextVNode, parentDom, lifecycle, context, isSVG, isRecycling);
 	} else {
 		const dom = lastVNode.dom;
+		
+		Object.keys(dom.dataset).forEach((key) => delete dom.dataset[key] );
+		dom.style.cssText = "";
+		
 		const lastProps = lastVNode.props;
 		const nextProps = nextVNode.props;
 		const lastChildren = lastVNode.children;


### PR DESCRIPTION
Remove dataset and inline styles from dom elements on vnode recycle.

 *Before* submitting a PR please:
 - Make sure you have based your branch off the [dev branch](https://github.com/infernojs/inferno/tree/dev).
 - Submit your PR against the [dev branch](https://github.com/infernojs/inferno/tree/dev).
 - Run `npm run build` and check that the build succeeds.
 - Ensure that the PR hasn't been submitted before.

---

## PR Template

**Objective**

This PR removes dataset and inline styles from dom elements on vnode recycle.

**Closes Issue**

It closes Issue #...
