### PR TITLE
Fix issue with renderToStream implementation

### DIFF
--- a/packages/inferno-server/src/renderToString.queuestream.ts
+++ b/packages/inferno-server/src/renderToString.queuestream.ts
@@ -113,6 +113,12 @@ export class RenderQueueStream extends Readable {
 
 	renderVNodeToQueue(vNode, context, firstChild, position) {
 
+		// In case render returns invalid stuff
+		if (isInvalid(vNode)) {
+			this.addToQueue('<!--!-->', position);
+			return;
+		}
+
 		const flags = vNode.flags;
 		const type = vNode.type;
 		const props = vNode.props || EMPTY_OBJ;
@@ -172,16 +178,9 @@ export class RenderQueueStream extends Readable {
 				const nextVNode = instance.render(props, vNode.context);
 				instance._pendingSetState = false;
 
-				// In case render returns invalid stuff
-				if (isInvalid(nextVNode)) {
-					this.addToQueue('<!--!-->', position);
-				}
 				this.renderVNodeToQueue(nextVNode, context, true, position);
 			} else {
 				const nextVNode = type(props, context);
-				if (isInvalid(nextVNode)) {
-					this.addToQueue('<!--!-->', position);
-				}
 				this.renderVNodeToQueue(nextVNode, context, true, position);
 			}
 		// If an element

--- a/packages/inferno-server/src/renderToString.stream.ts
+++ b/packages/inferno-server/src/renderToString.stream.ts
@@ -123,7 +123,7 @@ export class RenderStream extends Readable {
 						}
 						insertComment = true;
 					}
-					return this.renderNode(child, context, false)
+					return Promise.resolve(this.renderNode(child, context, false))
 						.then((_insertComment) => {
 							if (child.flags & VNodeFlags.Text) {
 								return true;


### PR DESCRIPTION
**Objective**

This PR fixes an issue where sometimes `this.renderNode` inside of renderToStream returns undefined which creates an unhandled exception when trying to call `.then()` on it.

**Closes Issue**

It closes Issue #861
