### PR TITLE
Set props, state and context after check shouldUpdate

### DIFF
--- a/packages/inferno-component/src/index.ts
+++ b/packages/inferno-component/src/index.ts
@@ -283,11 +283,11 @@ export default class Component<P, S> implements ComponentLifecycle<P, S> {
 				}
 			}
 
+			const shouldUpdate = this.shouldComponentUpdate(nextProps, nextState, context);
+
 			this.props = nextProps;
 			this.state = nextState;
 			this.context = context;
-
-			const shouldUpdate = this.shouldComponentUpdate(nextProps, nextState, context);
 
 			if (shouldUpdate || force) {
 				this._blockSetState = true;


### PR DESCRIPTION
PR https://github.com/infernojs/inferno/pull/871 has a bug: `this.props` has been equal to `nextProps`.

**Closes Issue**

It closes Issue #870 #871 
