### PR TITLE
Fix references to document.body in Inferno.render()

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ const message = "Hello world";
 Inferno.render(
   <MyComponent message={ message } />,
   document.getElementById("app")
-)
+);
 ```
 Furthermore, Inferno also uses ES6 components like React:
 
@@ -91,7 +91,10 @@ class MyComponent extends Component {
   }
 }
 
-Inferno.render(<MyComponent />, document.body);
+Inferno.render(
+  <MyComponent />,
+  document.getElementById("app")
+);
 ```
 
 ### More Examples
@@ -227,7 +230,7 @@ Inferno in this way is called a "controlled component".
 ```javascript
 import Inferno from 'inferno';
 
-Inferno.render(<div />, document.body);
+Inferno.render(<div />, document.getElementById("app"));
 ```
 
 Render a virtual node into the DOM in the supplied container given the supplied virtual DOM. If the virtual node was previously rendered
@@ -272,7 +275,10 @@ class BasicComponent extends Component {
     }
 }
 
-Inferno.render(createElement(BasicComponent, { title: 'abc' }), document.body);
+Inferno.render(
+  createElement(BasicComponent, { title: 'abc' }),
+  document.getElementById("app")
+);
 ```
 
 ### `Component` (package: `inferno-component`)
@@ -462,7 +468,10 @@ function FunctionalComponent({ props }) {
 	return <div>Hello world</div>;
 }
 
-Inferno.render(<FunctionalComponent onComponentDidMount={ mounted } />, document.body);
+Inferno.render(
+  <FunctionalComponent onComponentDidMount={ mounted } />,
+  document.getElementById("app")
+);
 ```
 
 Please note: class components (ES2015 classes) from `inferno-component` **do not** support the same lifecycle events (they have their own lifecycle events that work as methods on the class itself).

--- a/packages/inferno-compat/README.md
+++ b/packages/inferno-compat/README.md
@@ -114,5 +114,5 @@ class Foo extends React.Component {
 
 ReactDOM.render((
     <Foo a="a">test</Foo>
-), document.body);
+), document.getElementById("app"));
 ```

--- a/packages/inferno-create-element/readme.md
+++ b/packages/inferno-create-element/readme.md
@@ -13,8 +13,8 @@ npm install inferno-create-element
 import createElement from 'inferno-create-element';
 import Inferno from 'inferno';
 
-Inferno.render(createElement('div', { className: 'test' }, "I'm a child!"), document.body);
+Inferno.render(
+  createElement('div', { className: 'test' }, "I'm a child!"),
+  document.getElementById("app")
+);
 ```
-
-
-


### PR DESCRIPTION
Updates to documentation so every `Inferno.render()` example mounts to `document.getElementById('app')` instead of `document.body`.

This PR fixes #890 