### PR TITLE
Adds inferno-compat support for iterable children like Immutable List instances

### DIFF
--- a/packages/inferno-compat/__tests__/compat_children.spec.jsx
+++ b/packages/inferno-compat/__tests__/compat_children.spec.jsx
@@ -116,20 +116,17 @@ describe('Compat Children', () => {
 		};
 	}
 
-	it.skip('Should render element with an iterable of one text string', function () {
+	it('Should render element with an iterable of one text string', function () {
 		const iterable = arrayAsBasicIterator(['generated body text']);
 		const element = createElement('div', null, iterable);
 		expect(isValidElement(element)).to.be.true;
 
 		renderCompatTestElement(element);
 
-		// current actual behavior does not support iterables:
-		// expect(container.innerHTML).to.equal(innerHTML('<div></div>'));
-
 		expect(container.innerHTML).to.equal(innerHTML('<div>generated body text</div>'));
 	});
 
-	it.skip('Should render element with an iterable of one child element', function () {
+	it('Should render element with an iterable of one child element', function () {
 		const child = createElement('span', null, 'generated child body text');
 		expect(isValidElement(child)).to.be.true;
 
@@ -139,13 +136,10 @@ describe('Compat Children', () => {
 
 		renderCompatTestElement(element);
 
-		// current actual behavior does not support iterables:
-		// expect(container.innerHTML).to.equal(innerHTML('<div></div>'));
-
 		expect(container.innerHTML).to.equal(innerHTML('<div><span>generated child body text</span></div>'));
 	});
 
-	it.skip('Should render element with an iterable of a child element and a string', function () {
+	it('Should render element with an iterable of a child element and a string', function () {
 		const child = createElement('span', null, 'generated child body text');
 		expect(isValidElement(child)).to.be.true;
 
@@ -154,9 +148,6 @@ describe('Compat Children', () => {
 		expect(isValidElement(element)).to.be.true;
 
 		renderCompatTestElement(element);
-
-		// current actual behavior does not support iterables:
-		// expect(container.innerHTML).to.equal(innerHTML('<div></div>'));
 
 		expect(container.innerHTML).to.equal(innerHTML('<div><span>generated child body text</span>generated body text</div>'));
 	});

--- a/packages/inferno-compat/__tests__/compat_children.spec.jsx
+++ b/packages/inferno-compat/__tests__/compat_children.spec.jsx
@@ -1,0 +1,164 @@
+import { expect } from 'chai';
+import { render } from 'inferno';
+import { innerHTML } from 'inferno/test/utils';
+import { createElement, isValidElement } from '../dist-es';
+
+describe('Compat Children', () => {
+	let container;
+
+	beforeEach(function () {
+		container = document.createElement('div');
+		document.body.appendChild(container);
+	});
+
+	afterEach(function () {
+		render(null, container);
+		container.innerHTML = '';
+		document.body.removeChild(container);
+	});
+
+	function renderCompatTestElement(element) {
+		render(element, container);
+	}
+
+	it('Should render element with a text string', function () {
+		const element = createElement('div', null, 'body text');
+		expect(isValidElement(element)).to.be.true;
+
+		renderCompatTestElement(element);
+
+		expect(container.innerHTML).to.equal(innerHTML('<div>body text</div>'));
+	});
+
+	it('Should render element with an array of one text string', function () {
+		const element = createElement('div', null, ['body text']);
+		expect(isValidElement(element)).to.be.true;
+
+		renderCompatTestElement(element);
+
+		expect(container.innerHTML).to.equal(innerHTML('<div>body text</div>'));
+	});
+
+	it('Should render element with an array of two text strings', function () {
+		const element = createElement('div', null, [ 'first text', 'second text' ]);
+		expect(isValidElement(element)).to.be.true;
+
+		renderCompatTestElement(element);
+
+		expect(container.innerHTML).to.equal(innerHTML('<div>first textsecond text</div>'));
+	});
+
+	it('Should render element with child element', function () {
+		const child = createElement('span', null, 'child body text');
+		expect(isValidElement(child)).to.be.true;
+
+		const element = createElement('div', null, child);
+		expect(isValidElement(element)).to.be.true;
+
+		renderCompatTestElement(element);
+
+		expect(container.innerHTML).to.equal(innerHTML('<div><span>child body text</span></div>'));
+	});
+
+	it('Should render element with an array of one child element', function () {
+		const child = createElement('span', null, 'child body text');
+		expect(isValidElement(child)).to.be.true;
+
+		const element = createElement('div', null, [child]);
+		expect(isValidElement(element)).to.be.true;
+
+		renderCompatTestElement(element);
+
+		expect(container.innerHTML).to.equal(innerHTML('<div><span>child body text</span></div>'));
+	});
+
+	it('Should render element with an array of two child elements', function () {
+		const first_child = createElement('span', null, 'first text');
+		expect(isValidElement(first_child)).to.be.true;
+
+		const second_child = createElement('span', null, 'second text');
+		expect(isValidElement(second_child)).to.be.true;
+
+		const element = createElement('div', null, [ first_child, second_child ]);
+		expect(isValidElement(element)).to.be.true;
+
+		renderCompatTestElement(element);
+
+		expect(container.innerHTML).to.equal(innerHTML('<div><span>first text</span><span>second text</span></div>'));
+	});
+
+	it('Should render element with an array of a string and a child element', function () {
+		const second_child = createElement('span', null, 'second text');
+		expect(isValidElement(second_child)).to.be.true;
+
+		const element = createElement('div', null, [ 'first text', second_child ]);
+		expect(isValidElement(element)).to.be.true;
+
+		renderCompatTestElement(element);
+
+		expect(container.innerHTML).to.equal(innerHTML('<div>first text<span>second text</span></div>'));
+	});
+
+	function arrayAsBasicIterator(array) {
+		return {
+			[Symbol.iterator]: function () {
+				let idx = 0;
+				return {
+					next() {
+						if (idx < array.length) {
+							return { value: array[idx++], done: false };
+						} else {
+							return { done: true };
+						}
+					}
+				};
+			}
+		};
+	}
+
+	it.skip('Should render element with an iterable of one text string', function () {
+		const iterable = arrayAsBasicIterator(['generated body text']);
+		const element = createElement('div', null, iterable);
+		expect(isValidElement(element)).to.be.true;
+
+		renderCompatTestElement(element);
+
+		// current actual behavior does not support iterables:
+		// expect(container.innerHTML).to.equal(innerHTML('<div></div>'));
+
+		expect(container.innerHTML).to.equal(innerHTML('<div>generated body text</div>'));
+	});
+
+	it.skip('Should render element with an iterable of one child element', function () {
+		const child = createElement('span', null, 'generated child body text');
+		expect(isValidElement(child)).to.be.true;
+
+		const iterable = arrayAsBasicIterator([child]);
+		const element = createElement('div', null, iterable);
+		expect(isValidElement(element)).to.be.true;
+
+		renderCompatTestElement(element);
+
+		// current actual behavior does not support iterables:
+		// expect(container.innerHTML).to.equal(innerHTML('<div></div>'));
+
+		expect(container.innerHTML).to.equal(innerHTML('<div><span>generated child body text</span></div>'));
+	});
+
+	it.skip('Should render element with an iterable of a child element and a string', function () {
+		const child = createElement('span', null, 'generated child body text');
+		expect(isValidElement(child)).to.be.true;
+
+		const iterable = arrayAsBasicIterator([ child, 'generated body text' ]);
+		const element = createElement('div', null, iterable);
+		expect(isValidElement(element)).to.be.true;
+
+		renderCompatTestElement(element);
+
+		// current actual behavior does not support iterables:
+		// expect(container.innerHTML).to.equal(innerHTML('<div></div>'));
+
+		expect(container.innerHTML).to.equal(innerHTML('<div><span>generated child body text</span>generated body text</div>'));
+	});
+
+});

--- a/packages/inferno-compat/src/index.ts
+++ b/packages/inferno-compat/src/index.ts
@@ -16,7 +16,12 @@ import {
 	Props,
 	EMPTY_OBJ
 } from 'inferno';
-import { NO_OP } from 'inferno-shared';
+import {
+	NO_OP,
+	isArray,
+	isString,
+	isFunction
+} from 'inferno-shared';
 import Component from 'inferno-component';
 import _VNodeFlags from 'inferno-vnode-flags';
 
@@ -77,7 +82,7 @@ const Children = {
 		if (isNullOrUndef(children)) {
 			return [];
 		}
-		return Array.isArray && Array.isArray(children) ? children : ARR.concat(children);
+		return isArray(children) ? children : ARR.concat(children);
 	}
 };
 
@@ -161,6 +166,14 @@ const injectStringRefs = function (originalFunction) {
 		}
 		if (typeof name === 'string') {
 			normalizeProps(name, props);
+		}
+
+		// React supports iterable children, in addition to Array-like
+		for (let i = 0, len = children.length; i < len; i++) {
+			let child = children[i];
+			if (child && !isArray(child) && !isString(child) && isFunction(child[Symbol.iterator])) {
+				children[i] = child = Array.from(child);
+			}
 		}
 		return originalFunction(name, props, ...children);
 	};


### PR DESCRIPTION
**Objective**

This PR adds support for iterable children (such as [Immutable List](https://facebook.github.io/immutable-js/docs/#/List) instances) for the inferno-compat subproject. React supports this and it is used by SlateJS.

**Closes Issue**

The PR fixes the initial no-content problem behind #859 and correlated [SlateJS issue #634](https://github.com/ianstormtaylor/slate/issues/634)

**Commentary**
I expect there is a better place in the code to address support for iterable children. That said, this small patch passes Inferno's build and test scripts, and successfully makes [shanewholloway/inferno-slate-compat](https://github.com/shanewholloway/inferno-slate-compat) render the SlateJS interface in Inferno.