### PR TITLE
#910: Default unmounted to false in Component

### DIFF
--- a/packages/inferno-component/src/index.ts
+++ b/packages/inferno-component/src/index.ts
@@ -178,7 +178,7 @@ export default class Component<P, S> implements ComponentLifecycle<P, S> {
 	_pendingState = {};
 	_lastInput = null;
 	_vNode = null;
-	_unmounted = true;
+	_unmounted = false;
 	_lifecycle = null;
 	_childContext = null;
 	_patch = null;


### PR DESCRIPTION
**Objective**

This PR defaults `_unmounted` to true in `inferno-component` to add compatibility with kadira storybook

**Closes Issue**

It closes Issue #910
