### PR TITLE
Fix issue #915

### DIFF
--- a/packages/inferno-compat/__tests__/svg.spec.jsx
+++ b/packages/inferno-compat/__tests__/svg.spec.jsx
@@ -14,14 +14,21 @@ describe('svg', () => {
 	});
 
 	it('Should work with normal svg attributes', () => {
-		render(createElement('svg', null, [
+		render(createElement('svg', {
+			height: '16',
+			width: '16',
+			viewBox: '0 0 1024 1024'
+		}, [
 			createElement('stop', {
 				offset: 0,
 				stopColor: 'white',
-				stopOpacity: 0.5
+				stopOpacity: 0.5,
 			})
 		]), container);
 
+		expect(container.firstChild.getAttribute('viewBox')).to.equal('0 0 1024 1024');
+		expect(container.firstChild.getAttribute('height')).to.equal('16');
+		expect(container.firstChild.getAttribute('width')).to.equal('16');
 		expect(container.firstChild.firstChild.tagName).to.equal('stop');
 		expect(container.firstChild.firstChild.getAttribute('stop-color')).to.equal('white');
 		expect(container.firstChild.firstChild.getAttribute('stop-opacity')).to.equal('0.5');

--- a/packages/inferno-compat/src/index.ts
+++ b/packages/inferno-compat/src/index.ts
@@ -122,8 +122,9 @@ function normalizeProps(name: string, props: Props | any) {
 			props.onDblClick = props[ prop ];
 			delete props[ prop ];
 		}
-		if (SVGDOMPropertyConfig[ prop ]) {
-			props[ SVGDOMPropertyConfig[ prop ] ] = props[ prop ];
+		let mappedProp = SVGDOMPropertyConfig[ prop ];
+		if (mappedProp && mappedProp !== prop) {
+			props[ mappedProp ] = props[ prop ];
 			delete props[ prop ];
 		}
 	}


### PR DESCRIPTION
## Fix Issue #915

**Objective**

When SVG attributes are mapped to the same name as they are original, they were being deleted. This resulted in attributes like viewBox not being passed through.

**Closes Issue**

It closes Issue #915 
