### PR TITLE
Fix devtools crashes when 0 is only vnode child

### DIFF
--- a/packages/inferno-devtools/src/bridge.ts
+++ b/packages/inferno-devtools/src/bridge.ts
@@ -280,7 +280,7 @@ function createReactDOMComponent(vNode, parentDom) {
 		return null;
 	}
 	const type = vNode.type;
-	const children = vNode.children;
+	const children = vNode.children === 0 ? vNode.children.toString() : vNode.children;
 	const props = vNode.props;
 	const dom = vNode.dom;
 	const isText = (flags & VNodeFlags.Text) || isStringOrNumber(vNode);


### PR DESCRIPTION
**Objective**

Fixes edge case described in #713

**Closes Issue**

It closes Issue #713
