### PR TITLE
fix inferno-shared exports

### DIFF
--- a/packages/inferno-shared/index.js
+++ b/packages/inferno-shared/index.js
@@ -1,3 +1,3 @@
-module.exports = require('./dist').default;
+module.exports = require('./dist');
 module.exports.default = module.exports;
 


### PR DESCRIPTION
**Objective**

`inferno-shared@canary` exports `default` field from `dist/index.js` which does not exist and produces exception
```javascript
Uncaught TypeError: Cannot set property 'default' of undefined
    at index.js:2
```

This PR fixes this issue.
