### PR TITLE
fix inferno-devtools exports

### DIFF
--- a/packages/inferno-devtools/index.js
+++ b/packages/inferno-devtools/index.js
@@ -1,3 +1,3 @@
-module.exports = require('./dist').default;
+module.exports = require('./dist');
 module.exports.default = module.exports;
 


### PR DESCRIPTION
**Objective**

`inferno-devtools` exports default field which does not exist and produces exception

```
Uncaught TypeError: Cannot set property 'default' of undefined
    at index.js:2
```
PR fixes exports