### PR TITLE
Fix inferno-router need the path-to-regexp-es6 

### DIFF
--- a/packages/inferno-router/package.json
+++ b/packages/inferno-router/package.json
@@ -34,7 +34,8 @@
   },
   "rollup": {
     "bundledDependencies": [
-      "inferno-shared"
+      "inferno-shared",
+      "path-to-regexp-es6"
     ],
     "moduleName": "Inferno.Router",
     "moduleGlobals": {


### PR DESCRIPTION


---

**Fix inferno-router need the bundledDependencies called path-to-regexp-es6**

the routing examples do not work,it need inferno-router,but inferno-router not include path-to-regexp-es6