### PR TITLE
Call setState callback in context of component

### DIFF
--- a/packages/inferno-component/src/index.ts
+++ b/packages/inferno-component/src/index.ts
@@ -178,7 +178,7 @@ function applyState<P, S>(component: Component<P, S>, force: boolean, callback: 
 		component._pendingState = {};
 	}
 	if (!isNullOrUndef(callback)) {
-		callback();
+		callback.call(component);
 	}
 }
 


### PR DESCRIPTION
**Objective**

When a callback is passed to setState, it's context should be set to the component. This matches React's behavior, and improves compatibility when attempting to use other libraries, such as react-datetime, which depends on this behavior.

