### PR TITLE
allows to use <Route /> without component prop

### DIFF
--- a/packages/inferno-router/__tests__/components.spec.jsx
+++ b/packages/inferno-router/__tests__/components.spec.jsx
@@ -334,6 +334,32 @@ describe('Router (jsx)', () => {
 				done();
 			});
 		});
+
+		it('should render IndexRoute when root Route without component prop used', () => {
+			render(
+				<Router history={ browserHistory }>
+					<Route path="/">
+						<IndexRoute component={ () => <div>Good</div> }/>
+						<Route path={'/test'} component={ () => <div>Bad</div> }/>
+					</Route>
+				</Router>, container
+			);
+
+			expect(innerHTML(container.innerHTML)).to.equal('<div>Good</div>');
+		});
+
+		it('should render /test Route when root Route without component prop used', () => {
+			render(
+				<Router url={'/test'} history={ browserHistory }>
+					<Route path="/">
+						<IndexRoute component={ () => <div>Bad</div> }/>
+						<Route path={'/test'} component={ () => <div>Good</div> }/>
+					</Route>
+				</Router>, container
+			);
+
+			expect(container.innerHTML).to.equal('<div>Good</div>');
+		});
 	});
 });
 

--- a/packages/inferno-router/src/Route.ts
+++ b/packages/inferno-router/src/Route.ts
@@ -2,6 +2,7 @@ import { VNode } from 'inferno';
 import Component from 'inferno-component';
 import createElement from 'inferno-create-element';
 import { rest } from './utils';
+import { isArray } from 'inferno-shared';
 
 const resolvedPromise = Promise.resolve();
 
@@ -94,7 +95,7 @@ export default class Route extends Component<IRouteProps, any> {
 
 		const resolvedComponent = component || asyncComponent;
 		if (!resolvedComponent) {
-			return null;
+			return !isArray(children) ? children : null;
 		}
 
 		return createElement(resolvedComponent, props, children);


### PR DESCRIPTION
**Objective**

With this PR `<Route />` can be used without specifying `component` prop. I used almost same logic as `react-router` does: if component to render wasn't found for Route, then children object will be rendered; if children is an Array, then `null` will be returned from `render` method of `Route`.

**P.S.** I'm not sure i wrote tests properly.

**Closes Issue**

It closes Issue #977
