### PR TITLE
Added failing tests and bugfix for URLs that contain percent-encoded values.

### DIFF
--- a/packages/inferno-router/__tests__/router.spec.jsx
+++ b/packages/inferno-router/__tests__/router.spec.jsx
@@ -2,7 +2,7 @@ import { expect } from 'chai';
 import { createBrowserHistory, createMemoryHistory } from 'history';
 import { cloneVNode, render } from 'inferno';
 import { innerHTML } from 'inferno/test/utils';
-import { IndexRoute, Link, Route, Router, RouterContext } from '../dist-es';
+import { IndexRoute, Link, Route, Router, RouterContext, match } from '../dist-es';
 
 const browserHistory = createBrowserHistory();
 const browserHistoryWithBaseName = createBrowserHistory({ basename: '/basename-prefix' });
@@ -90,6 +90,17 @@ describe('Router (jsx)', () => {
 				container
 			);
 			expect(container.innerHTML).to.equal(innerHTML('<div><p>Parent Component</p><div>Child is bar</div></div>'));
+		});
+		it('should render the child and inherit parent (URL containing percent encoded value)', () => {
+			render(
+				<Router url={ '/foo/100%25' } history={ browserHistory }>
+					<Route path={ '/foo' } component={ ({ children }) => <div><p>Parent Component</p>{ children }</div> }>
+						<Route path={ '/:test' } component={ ({ params }) => <div>Child is { params.test }</div> }/>
+					</Route>
+				</Router>,
+				container
+			);
+			expect(container.innerHTML).to.equal(innerHTML('<div><p>Parent Component</p><div>Child is 100%</div></div>'));
 		});
 		it('should render the child with the longest path', () => {
 			render(
@@ -261,6 +272,66 @@ describe('Router (jsx)', () => {
 			expect(
 				() => render(<RouterContext location={ null }/>, container)
 			).to.throw(TypeError);
+		});
+		it('should fail when `matched` is not provided', () => {
+			expect(
+				() => render(<RouterContext location={ '/' } matched={ null }/>, container)
+			).to.throw(TypeError);
+		});
+		it('should pass when `location` is provided', () => {
+			const url = '/';
+			const matched = <GoodComponent/>;
+			const actual = render(<RouterContext location={ url } matched={ matched }/>, container);
+			expect(actual.props.location).to.equal(url);
+			expect(actual.props.matched).to.equal(matched);
+		});
+		it('should pass when `location` is provided and has percent encoded value', () => {
+			const url = '/100%25';
+			const matched = <GoodComponent/>;
+			const actual = render(<RouterContext location={ url } matched={ matched }/>, container);
+			expect(actual.props.location).to.equal(url);
+			expect(actual.props.matched).to.equal(matched);
+		});
+	});
+	describe('#match', () => {
+		it('should find route when url has normal value', () => {
+			const url = '/search/foo';
+			const history = createMemoryHistory();
+			history.push(url);
+
+			const router = <Router history={ history }>
+				<Route path="/" component={ BadComponent }>
+					<Route path="search/:searchData" component={ GoodComponent }/>
+				</Route>
+			</Router>;
+			const renderProps = match(router, url);
+
+			const actual = render(<RouterContext {...renderProps}/>, container);
+
+			expect(actual.props.location).to.equal('/');
+			expect(actual.props.matched.props.history.location.pathname).to.equal(url);
+			expect(actual.props.matched.props.params.searchData).to.equal('foo');
+			expect(actual.props.matched.props.children.props.component).to.equal(BadComponent);
+			expect(actual.props.matched.props.children.props.children.props.component).to.equal(GoodComponent);
+		});
+		it('should find route when url has percent encoded value', () => {
+			const url = '/search/100%25';
+			const history = createMemoryHistory();
+			history.push(url);
+			const router = <Router history={ history }>
+				<Route path="/" component={ BadComponent }>
+					<Route path="search/:searchData" component={ GoodComponent }/>
+				</Route>
+			</Router>;
+			const renderProps = match(router, history.location.pathname);
+
+			const actual = render(<RouterContext {...renderProps}/>, container);
+
+			expect(actual.props.location).to.equal('/');
+			expect(actual.props.matched.props.history.location.pathname).to.equal(url.replace('%25', '%'));
+			expect(actual.props.matched.props.params.searchData).to.equal('100%');
+			expect(actual.props.matched.props.children.props.component).to.equal(BadComponent);
+			expect(actual.props.matched.props.children.props.children.props.component).to.equal(GoodComponent);
 		});
 	});
 

--- a/packages/inferno-router/src/match.ts
+++ b/packages/inferno-router/src/match.ts
@@ -22,7 +22,7 @@ const cache: Map<string, IMatchRegex> = new Map();
  */
 export default function match(routes, currentURL: any) {
 	const location: string = getURLString(currentURL);
-	return matchRoutes(toArray(routes), location, '/');
+	return matchRoutes(toArray(routes), encodeURI(location), '/');
 }
 
 /**

--- a/packages/inferno-router/src/utils.ts
+++ b/packages/inferno-router/src/utils.ts
@@ -38,7 +38,7 @@ export function mapSearchParams(search): any {
 
 	for (let i = 0, len = fragments.length; i < len; i++) {
 		const fragment = fragments[ i ];
-		const [ k, v ] = fragment.split('=').map(mapFragment);
+		const [ k, v ] = fragment.split('=').map(mapFragment).map(decodeURIComponent);
 
 		if (map[ k ]) {
 			map[ k ] = isArray(map[ k ]) ? map[ k ] : [ map[ k ] ];


### PR DESCRIPTION
**Objective**

This PR shows a bug in the handling of URLs with percent encoded characters. This reproduces a bug I encountered in my own project. If I'm doing something wrong, let me know and I'll correct these tests so that they pass.

`npm run-script test:quick` will show the failure.

**Closes Issue**

No related issues.

Update: I pushed a 2nd commit with updated tests and a bug fix.