### PR TITLE
Fix the bug #1010

### DIFF
--- a/packages/inferno/src/DOM/events/delegation.ts
+++ b/packages/inferno/src/DOM/events/delegation.ts
@@ -26,8 +26,10 @@ export function handleEvent(name, lastEvent, nextEvent, dom) {
 		}
 		delegatedRoots.items.set(dom, nextEvent);
 	} else if (delegatedRoots) {
-		delegatedRoots.count--;
-		delegatedRoots.items.delete(dom);
+		if (delegatedRoots.items.has(dom)) {
+ 			delegatedRoots.count--;
+ 			delegatedRoots.items.delete(dom);
+ 		}
 		if (delegatedRoots.count === 0) {
 			document.removeEventListener(normalizeEventName(name), delegatedRoots.docEvent);
 			delegatedEvents.delete(name);


### PR DESCRIPTION
There is a 'counter leak' when some component is mounted and unmounted in second root. When delegatedRoots.count reach zero, app stop to react on clicks. delegatedRoots.items has still plenty of delegated roots

delegatedRoots.count should be decremented only when delete is successful. delete is successful when item exists in collection, the subsequent delete decrements counter only

