### PR TITLE
Add missing function argument type for Ref type

### DIFF
--- a/packages/inferno/src/core/VNodes.ts
+++ b/packages/inferno/src/core/VNodes.ts
@@ -13,7 +13,7 @@ import { normalize } from './normalization';
 import { options } from './options';
 
 export type InfernoInput = VNode | null | string | number;
-export type Ref = (node?) => void | null;
+export type Ref = (node?: Element | null) => void | null;
 export type InfernoChildren = string | number | boolean | undefined | VNode | Array<string | number | VNode> | null;
 export type Type = string | null | Function;
 


### PR DESCRIPTION
**Objective**

This PR fixes an issue that prevents TypeScript from being able to compile projects configured with the noImplicitAny option enabled.

This issue appeared since Inferno 1.6.x, prior versions worked fine.