### PR TITLE
test-utils: add Jest snapshot serializer functions

### DIFF
--- a/packages/inferno-test-utils/src/index.ts
+++ b/packages/inferno-test-utils/src/index.ts
@@ -197,7 +197,7 @@ export function getTagNameOfVNode(inst: any) {
 
 import {
 	renderToSnapshot,
-	vNodeToSnapshot,
+	vNodeToSnapshot
 } from './jest';
 
 export default {

--- a/packages/inferno-test-utils/src/index.ts
+++ b/packages/inferno-test-utils/src/index.ts
@@ -88,7 +88,7 @@ export function renderIntoDocument(input: InfernoInput): InfernoChildren {
 
 // Recursive Finder Functions
 
-export function findAllInRenderedTree(renderedTree: any, predicate: (vNode: VNode) => boolean): VNode[]|any {
+export function findAllInRenderedTree(renderedTree: any, predicate: (vNode: VNode) => boolean): VNode[] | any {
 	if (isRenderedClassComponent(renderedTree)) {
 		return findAllInVNodeTree(renderedTree._lastInput, predicate);
 	} else {
@@ -98,7 +98,7 @@ export function findAllInRenderedTree(renderedTree: any, predicate: (vNode: VNod
 
 export function findAllInVNodeTree(vNodeTree: VNode, predicate: (vNode: VNode) => boolean): any {
 	if (isVNode(vNodeTree)) {
-		let result: VNode[] = predicate(vNodeTree) ? [ vNodeTree ] : [];
+		let result: VNode[] = predicate(vNodeTree) ? [vNodeTree] : [];
 		const children: any = vNodeTree.children;
 
 		if (isRenderedClassComponent(children)) {
@@ -135,7 +135,7 @@ function findOneOf(tree: any, filter: any, name: string, finder: Function): any 
 	if (all.length > 1) {
 		throwError(`Did not find exactly one match (found ${all.length}) for ${name}: ${filter}`);
 	} else {
-		return all[ 0 ];
+		return all[0];
 	}
 }
 
@@ -189,82 +189,16 @@ export function findVNodeWithType(vNodeTree: VNode, type: string | Function): VN
 	return findOneOf(vNodeTree, type, 'VNode', scryVNodesWithType);
 }
 
-// Jest Snapshot Utilities
-// Jest formats it's snapshots prettily because it knows how to play with the React test renderer.
-// Symbols and algorithm have been reversed from the following file:
-// https://github.com/facebook/react/blob/v15.4.2/src/renderers/testing/ReactTestRenderer.js#L98
 export function getTagNameOfVNode(inst: any) {
 	return (inst && inst.dom && inst.dom.tagName.toLowerCase()) ||
 		(inst && inst._vNode && inst._vNode.dom && inst._vNode.dom.tagName.toLowerCase()) ||
 		undefined;
 }
 
-export function createSnapshotObject(object: object) {
-	Object.defineProperty(object, '$$typeof', {
-		value: Symbol.for('react.test.json')
-	});
-
-	return object;
-}
-
-export function vNodeToSnapshot(node: any) {
-	let object;
-	const children: any[] = [];
-
-	if (isDOMVNode(node)) {
-		const props = { ...node.props };
-
-		// Remove undefined props
-		Object.keys(props).forEach((propKey) => {
-			if (props[propKey] === undefined) {
-				delete props[propKey];
-			}
-		});
-
-		// Create the actual object that Jest will interpret as the snapshot for this VNode
-		object = createSnapshotObject({
-			type: getTagNameOfVNode(node),
-			props
-		});
-	}
-
-	if (Array.isArray(node.children)) {
-		node.children.forEach((child) => {
-			const asJSON = vNodeToSnapshot(child);
-			if (asJSON) {
-				children.push(asJSON);
-			}
-		});
-	} else if (typeof node.children === 'string') {
-		children.push(node.children);
-	} else if (typeof node.children === 'object' && node.children !== null) {
-		const asJSON = vNodeToSnapshot(node.children);
-		if (asJSON) {
-			children.push(asJSON);
-		}
-	}
-
-	if (object) {
-		object.children = children.length ? children : null;
-		return object;
-	}
-
-	if (children.length > 1) {
-		return children;
-	} else if (children.length === 1) {
-		return children[0];
-	}
-
-	return object;
-}
-
-export function renderToSnapshot(input: InfernoInput) {
-	const vnode = renderIntoDocument(input);
-	const snapshot = vNodeToSnapshot(vnode);
-	delete snapshot.props.children;
-
-	return snapshot;
-}
+import {
+	renderToSnapshot,
+	vNodeToSnapshot,
+} from './jest';
 
 export default {
 
@@ -309,7 +243,7 @@ export default {
 	findVNodeWithType,
 
 	getTagNameOfVNode,
-	createSnapshotObject,
+
 	vNodeToSnapshot,
 	renderToSnapshot
 };

--- a/packages/inferno-test-utils/src/jest.ts
+++ b/packages/inferno-test-utils/src/jest.ts
@@ -1,0 +1,85 @@
+import { VNode } from 'inferno';
+import { isArray, isNull, isObject, isString } from 'inferno-shared';
+import { getTagNameOfVNode, isDOMVNode, renderIntoDocument } from './index';
+
+// Jest Snapshot Utilities
+// Jest formats it's snapshots prettily because it knows how to play with the React test renderer.
+// Symbols and algorithm have been reversed from the following file:
+// https://github.com/facebook/react/blob/v15.4.2/src/renderers/testing/ReactTestRenderer.js#L98
+
+function createSnapshotObject(object: object) {
+	Object.defineProperty(object, '$$typeof', {
+		value: Symbol.for('react.test.json')
+	});
+
+	return object;
+}
+
+export function vNodeToSnapshot(node: VNode) {
+	let object;
+	const children: any[] = [];
+
+	if (isDOMVNode(node)) {
+		const props = { ...node.props };
+
+		// Remove undefined props
+		Object.keys(props).forEach((propKey) => {
+			if (props[propKey] === undefined) {
+				delete props[propKey];
+			}
+		});
+
+		// Create the actual object that Jest will interpret as the snapshot for this VNode
+		object = createSnapshotObject({
+			type: getTagNameOfVNode(node),
+			props
+		});
+	}
+
+	if (isArray(node.children)) {
+		node.children.forEach((child) => {
+			const asJSON = vNodeToSnapshot(child as VNode);
+			if (asJSON) {
+				children.push(asJSON);
+			}
+		});
+	} else if (isString(node.children)) {
+		children.push(node.children);
+	} else if (isObject(node.children) && !isNull(node.children)) {
+		const asJSON = vNodeToSnapshot(node.children);
+		if (asJSON) {
+			children.push(asJSON);
+		}
+	}
+
+	if (object) {
+		object.children = children.length ? children : null;
+		return object;
+	}
+
+	if (children.length > 1) {
+		return children;
+	} else if (children.length === 1) {
+		return children[0];
+	}
+
+	return object;
+}
+
+export function renderToSnapshot(input: VNode) {
+	const vnode = renderIntoDocument(input) as VNode;
+
+	if (!isNull(vnode.props)) {
+		const snapshot = vNodeToSnapshot(vnode.props.children as VNode);
+		delete snapshot.props.children;
+		return snapshot;
+	}
+
+	return undefined;
+}
+
+export default {
+	createSnapshotObject,
+	vNodeToSnapshot,
+	renderToSnapshot
+};


### PR DESCRIPTION
**Objective**

This PR adds new functions to the inferno-test-utils package. You can use them to better use Jest's snapshotting feature. 

E.g. using the new `inputToSnapshot` function in a Jest test file:
```js
test('Button label is properly set', () => {
    expect(inputToSnapshot(<Button label='Foo' />)).toMatchSnapshot();
});
```
...we'll get something like the following snapshot output from Jest (obv depends on the implementation of the `Button` component)...
```
exports[`Button label is properly set 1`] = `
<button
  href="#"
  onClick={[Function]}
  role="button"
>
  <span />
  <span>
    Foo
  </span>
</button>
`;
```

Note that I had to change some existing code in the implementation of `isDOMVNode`. I found that the existing implementation didn't catch VNodes of <input> elements created by a component. I assume that we _do_ in fact want those to be caught by isDOMVNode so I just went ahead and fixed it rather than opening a PR first. We can discuss if that's not the case.