### PR TITLE
devtools: fix React devtools crash when child is empty string

### DIFF
--- a/packages/inferno-devtools/src/bridge.ts
+++ b/packages/inferno-devtools/src/bridge.ts
@@ -260,13 +260,17 @@ function updateReactComponent(vNode, parentDom) {
 
 }
 
+function isInvalidChild(child) {
+	return isInvalid(child) || child === '';
+}
+
 function normalizeChildren(children, dom) {
 	if (isArray(children)) {
-		return children.filter((child) => !isInvalid(child)).map((child) =>
+		return children.filter((child) => !isInvalidChild(child)).map((child) =>
 			updateReactComponent(child, dom)
 		);
 	} else {
-		return !isInvalid(children) ? [ updateReactComponent(children, dom) ] : [];
+		return !(isInvalidChild(children) || children === '') ? [ updateReactComponent(children, dom) ] : [];
 	}
 }
 


### PR DESCRIPTION
This PR fixes a bug where the React Devtools would fatally crash with a "Cannot read property '_currentElement' of null" error when a component rendered an empty string as the contents of a DOM node. In these cases, `inferno-devtools` returns the child as a `null` renderedChild. However, the React Devtools extension requires every child to be an object so that it can check its various properties and decide how to render it.

I submitted a PR against the react-devtools to handle null children, but Dan says that nulls should not be reported and suggested it was an error with what Inferno is reporting. Note that while I say it appears to be an `inferno-compat` issue, I have since then reproduced it in vanilla Inferno, as seen in the example repo below. The problem therefore appears to come up because of the reporting that inferno-devtools does and it's decision making of what an invalid node is.

[I've made a repo to illustrate the problem.](https://github.com/doytch/empty-string-inferno-devtools-crash)

The fix I made is fairly simple and scoped tightly and fixes this bug. I initially tried editing the definition of `isInvalid()` itself but that broke a bunch of tests so I decided to keep the change localised.