### PR TITLE
Router link without context

### DIFF
--- a/packages/inferno-router/__tests__/components.spec.jsx
+++ b/packages/inferno-router/__tests__/components.spec.jsx
@@ -3,9 +3,7 @@ import { assert, spy } from 'sinon';
 import createMemoryHistory from 'history/createMemoryHistory';
 import { render } from 'inferno';
 import { innerHTML } from 'inferno/test/utils';
-import { warning } from 'inferno-shared'
 import { IndexLink, IndexRoute, Link, Route, Router } from '../dist-es';
-
 const browserHistory = createMemoryHistory();
 
 function TestComponent() {

--- a/packages/inferno-router/__tests__/components.spec.jsx
+++ b/packages/inferno-router/__tests__/components.spec.jsx
@@ -3,7 +3,9 @@ import { assert, spy } from 'sinon';
 import createMemoryHistory from 'history/createMemoryHistory';
 import { render } from 'inferno';
 import { innerHTML } from 'inferno/test/utils';
+import { warning } from 'inferno-shared'
 import { IndexLink, IndexRoute, Link, Route, Router } from '../dist-es';
+
 const browserHistory = createMemoryHistory();
 
 function TestComponent() {
@@ -149,6 +151,16 @@ describe('Router (jsx)', () => {
 
 			const notCalled = assert.notCalled;
 			notCalled(sinonSpy);
+		});
+
+		it('should show warning when used without <Router />', () => {
+			const sinonSpy = spy(console, 'warn');
+
+			render(<Link to="/">Link</Link>, container);
+
+			assert.called(sinonSpy);
+
+			sinonSpy.restore();
 		});
 	});
 

--- a/packages/inferno-router/src/Link.ts
+++ b/packages/inferno-router/src/Link.ts
@@ -1,16 +1,31 @@
 import { createVNode, VNode } from 'inferno';
-import { combineFrom, isBrowser } from 'inferno-shared';
+import { combineFrom, isBrowser, warning } from 'inferno-shared';
 import VNodeFlags from 'inferno-vnode-flags';
+
+function renderLink(classNm, children, otherProps) {
+	return createVNode(VNodeFlags.HtmlElement, 'a', classNm, children, otherProps);
+}
 
 export default function Link(props, { router }): VNode {
 	const { activeClassName, activeStyle, className, onClick, children, to, ...otherProps } = props;
-
-	otherProps.href = isBrowser ? router.createHref({ pathname: to }) : router.location.baseUrl ? router.location.baseUrl + to : to;
 
 	let classNm;
 	if (className) {
 		classNm = className as string;
 	}
+
+	if (!router) {
+		if (process.env.NODE_ENV !== 'production') {
+			warning('<Link/> component used outside of <Router/>. Fallback to <a> tag.');
+		}
+
+		otherProps.href = to;
+		otherProps.onClick = onClick;
+
+		return renderLink(classNm, children, otherProps);
+	}
+
+	otherProps.href = isBrowser ? router.createHref({ pathname: to }) : router.location.baseUrl ? router.location.baseUrl + to : to;
 
 	if (router.location.pathname === to) {
 		if (activeClassName) {
@@ -32,5 +47,5 @@ export default function Link(props, { router }): VNode {
 		router.push(to, e.target.textContent);
 	};
 
-	return createVNode(VNodeFlags.HtmlElement, 'a', classNm, children, otherProps);
+	return renderLink(classNm, children, otherProps);
 }


### PR DESCRIPTION
**Objective**

`<Link/>` component now could be used outside of `<Router/>`. In this case warning will be displayed in console in non production environment (`process.env.NODE_ENV !== 'production'`) and `<a/>` without router specific props will be rendered.

**Closes Issue**

It closes Issue #1026
