### PR TITLE
Fix inferno-redux props merging

### DIFF
--- a/packages/inferno-redux/__tests__/connect.spec.jsx
+++ b/packages/inferno-redux/__tests__/connect.spec.jsx
@@ -27,6 +27,14 @@ class BasicComponent1 extends Component {
 	}
 }
 
+class BasicComponent2 extends Component {
+	render() {
+		return (
+			<div>{this.props.a} {this.props.b} {this.props.c}</div>
+		);
+	}
+}
+
 describe('connect', () => {
 	let container;
 
@@ -141,5 +149,19 @@ describe('connect', () => {
 			expect(container.innerHTML).to.equal(innerHTML('<a>2</a>'));
 			done();
 		}, 10);
+	});
+
+	it('should override parentProps with stateProps and stateProps with dispatchProps', () => {
+		const store = createStore(state => state);
+		const mapDispatchToProps = dispatch => ({
+			a: 'dispatch'
+		});
+		const mapStateToProps = state => ({
+			a: 'state',
+			b: 'state'
+		});
+		const ConnectedComponent = connect(mapStateToProps, mapDispatchToProps)(BasicComponent2);
+		render(<ConnectedComponent store={store} a="parent" b="parent" c="parent"/>, container);
+		expect(container.innerHTML).to.equal(innerHTML('<div>dispatch state parent</div>'));
 	});
 });

--- a/packages/inferno-redux/src/connect.ts
+++ b/packages/inferno-redux/src/connect.ts
@@ -21,7 +21,7 @@ export type MapDispatchToProps =
 const errorObject = { value: null };
 const defaultMapStateToProps = (state) => ({}); // eslint-disable-line no-unused-vars
 const defaultMapDispatchToProps = (dispatch) => ({ dispatch });
-const defaultMergeProps = function(parentProps, stateProps, dispatchProps) {
+const defaultMergeProps = function(stateProps, dispatchProps, parentProps) {
 	const obj = {};
 
 	if (parentProps) {


### PR DESCRIPTION
**Objective**

The arguments in `defaultMergeProps` function were in wrong order. In
the line 95 the props are given to the function in the following order:

1. stateProps
2. dispatchProps
3. parentProps

Now the first argument of the `defaultMergeProps` was `parentProps`, so
any props set by the `mapStateToProps` would be overridden by the parent
object's props, which is unwanted behaviour.

Changed the props to correct order to fix this.