### PR TITLE
path-to-regexp@1.7.0 added as dependency

### DIFF
--- a/packages/inferno-router/package.json
+++ b/packages/inferno-router/package.json
@@ -31,6 +31,7 @@
     "inferno-create-element": "3.1.0",
     "inferno-shared": "^3.0.0",
     "inferno-vnode-flags": "^3.0.0",
+    "path-to-regexp": "^1.7.0",	
     "path-to-regexp-es6": "0.0.2"
   },
   "rollup": {


### PR DESCRIPTION
This PR is to add path-to-regexp@1.7.0 as dependency to inferno-router to make sure it installs and use the latest path-to-regexp. By default path-to-regexp-es6 required ANY version of path-to-regexp and if you use inferno-router with express 4 that depends on old path-to-regexp@0.1.7 you will end up inferno-router `match` functionality works incorrectly. 
