### PR TITLE
devtools: fixed bug where props weren't updated by React Devtools

### DIFF
--- a/packages/inferno-devtools/src/bridge.ts
+++ b/packages/inferno-devtools/src/bridge.ts
@@ -330,9 +330,6 @@ function createReactCompositeComponent(vNode) {
 	const dom = vNode.dom;
 
 	const compositeComponent = {
-		getName() {
-			return typeName(type);
-		},
 		_currentElement: {
 			key: normalizeKey(vNode.key),
 			props: vNode.props,
@@ -341,6 +338,9 @@ function createReactCompositeComponent(vNode) {
 		},
 		_instance: instance,
 		_renderedComponent: updateReactComponent(lastInput, dom),
+		getName() {
+			return typeName(type);
+		},
 		forceUpdate: instance.forceUpdate.bind(instance),
 		node: dom,
 		props: instance.props,

--- a/packages/inferno-devtools/src/bridge.ts
+++ b/packages/inferno-devtools/src/bridge.ts
@@ -338,10 +338,10 @@ function createReactCompositeComponent(vNode) {
 		},
 		_instance: instance,
 		_renderedComponent: updateReactComponent(lastInput, dom),
+		forceUpdate: instance.forceUpdate.bind(instance),
 		getName() {
 			return typeName(type);
 		},
-		forceUpdate: instance.forceUpdate.bind(instance),
 		node: dom,
 		props: instance.props,
 		setState: instance.setState.bind(instance),

--- a/packages/inferno/src/index.ts
+++ b/packages/inferno/src/index.ts
@@ -33,29 +33,21 @@ const version = '3.2.2';
 
 // we duplicate it so it plays nicely with different module loading systems
 export default {
+	EMPTY_OBJ, // used to shared common items between Inferno libs
+	NO_OP, // used to shared common items between Inferno libs
+	cloneVNode, // cloning
+	createRenderer, // DOM
+	createVNode, // core shapes
+	findDOMNode, // DOM
 	getFlagsForElementVnode,
-	linkEvent,
-	// core shapes
-	createVNode,
-
-	// cloning
-	cloneVNode,
-
-	// used to shared common items between Inferno libs
-	NO_OP,
-	EMPTY_OBJ,
-
-	// DOM
-	render,
-	findDOMNode,
-	createRenderer,
-	options,
-	version,
-
-	internal_patch,
 	internal_DOMNodeMap,
 	internal_isUnitlessNumber,
-	internal_normalize
+	internal_normalize,
+	internal_patch,
+	linkEvent,
+	options, // DOM
+	render, // DOM
+	version // DOM
 };
 
 export {


### PR DESCRIPTION
This PR fixes issue #1060 where updating the props on a component via the React Dev Tools didn't....actually update the props. Those changes are all in `packages/inferno-devtools/src/bridge.ts`

Also, since the tslint precommit hook was yelling at me about all the files that were still in error because of object key-ordering, I went ahead and fixed those as well.