### PR TITLE
Fixes XHTML namespace inside foreignObject of SVG. Fixes #1087

### DIFF
--- a/packages/inferno-create-element/__tests__/svg.spec.browser.js
+++ b/packages/inferno-create-element/__tests__/svg.spec.browser.js
@@ -343,4 +343,13 @@ describe('SVG (non-jsx)', () => {
 		render(template(), container);
 		expect(container.firstChild.getAttribute('class')).to.equal('class1 class2');
 	});
+
+	it('should respect XHTML namespace inside foreignObject of SVG', () => {
+		const template = () => createElement('svg', null, createElement('foreignObject', null, createElement('div')));
+
+		render(template(), container);
+		expect(container.firstChild.namespaceURI).to.equal('http://www.w3.org/2000/svg');
+		expect(container.firstChild.firstChild.namespaceURI).to.equal('http://www.w3.org/2000/svg');
+		expect(container.firstChild.firstChild.firstChild.namespaceURI).to.equal('http://www.w3.org/1999/xhtml');
+	});
 });

--- a/packages/inferno-create-element/__tests__/svg.spec.browser.js
+++ b/packages/inferno-create-element/__tests__/svg.spec.browser.js
@@ -345,11 +345,16 @@ describe('SVG (non-jsx)', () => {
 	});
 
 	it('should respect XHTML namespace inside foreignObject of SVG', () => {
-		const template = () => createElement('svg', null, createElement('foreignObject', null, createElement('div')));
+		const template = (extraElement) => createElement('svg', null, createElement('foreignObject', null, createElement('div', null, extraElement ? createElement('p') : null)));
 
-		render(template(), container);
+		render(template(false), container);
 		expect(container.firstChild.namespaceURI).to.equal('http://www.w3.org/2000/svg');
 		expect(container.firstChild.firstChild.namespaceURI).to.equal('http://www.w3.org/2000/svg');
 		expect(container.firstChild.firstChild.firstChild.namespaceURI).to.equal('http://www.w3.org/1999/xhtml');
+		render(template(true), container);
+		expect(container.firstChild.namespaceURI).to.equal('http://www.w3.org/2000/svg');
+		expect(container.firstChild.firstChild.namespaceURI).to.equal('http://www.w3.org/2000/svg');
+		expect(container.firstChild.firstChild.firstChild.namespaceURI).to.equal('http://www.w3.org/1999/xhtml');
+		expect(container.firstChild.firstChild.firstChild.firstChild.namespaceURI).to.equal('http://www.w3.org/1999/xhtml');
 	});
 });

--- a/packages/inferno/src/DOM/mounting.ts
+++ b/packages/inferno/src/DOM/mounting.ts
@@ -96,9 +96,9 @@ export function mountElement(vNode: VNode, parentDom: Element|null, lifecycle: L
 		if (isStringOrNumber(children)) {
 			setTextContent(dom, children as string | number);
 		} else if (isArray(children)) {
-			mountArrayChildren(children, dom, lifecycle, context, isSVG);
+			mountArrayChildren(children, dom, lifecycle, context, isSVG && vNode.type !== 'foreignObject');
 		} else if (isVNode(children as any)) {
-			mount(children as VNode, dom, lifecycle, context, isSVG);
+			mount(children as VNode, dom, lifecycle, context, isSVG && vNode.type !== 'foreignObject');
 		}
 	}
 	if (!isNull(props)) {

--- a/packages/inferno/src/DOM/mounting.ts
+++ b/packages/inferno/src/DOM/mounting.ts
@@ -95,10 +95,13 @@ export function mountElement(vNode: VNode, parentDom: Element|null, lifecycle: L
 	if (!isInvalid(children)) {
 		if (isStringOrNumber(children)) {
 			setTextContent(dom, children as string | number);
-		} else if (isArray(children)) {
-			mountArrayChildren(children, dom, lifecycle, context, isSVG && vNode.type !== 'foreignObject');
-		} else if (isVNode(children as any)) {
-			mount(children as VNode, dom, lifecycle, context, isSVG && vNode.type !== 'foreignObject');
+		} else {
+			const childrenIsSVG = isSVG === true && vNode.type !== 'foreignObject';
+			if (isArray(children)) {
+				mountArrayChildren(children, dom, lifecycle, context, childrenIsSVG);
+			} else if (isVNode(children as any)) {
+				mount(children as VNode, dom, lifecycle, context, childrenIsSVG);
+			}
 		}
 	}
 	if (!isNull(props)) {

--- a/packages/inferno/src/DOM/patching.ts
+++ b/packages/inferno/src/DOM/patching.ts
@@ -142,7 +142,8 @@ export function patchElement(lastVNode: VNode, nextVNode: VNode, parentDom: Elem
 		nextVNode.dom = dom;
 		isSVG = isSVG || (nextFlags & VNodeFlags.SvgElement) > 0;
 		if (lastChildren !== nextChildren) {
-			patchChildren(lastFlags, nextFlags, lastChildren, nextChildren, dom, lifecycle, context, isSVG, isRecycling);
+			const childrenIsSVG = isSVG === true && nextVNode.type !== 'foreignObject';
+			patchChildren(lastFlags, nextFlags, lastChildren, nextChildren, dom, lifecycle, context, childrenIsSVG, isRecycling);
 		}
 
 		// inlined patchProps  -- starts --


### PR DESCRIPTION
## PR Template

**Objective**

This PR fixes so that HTML elements inside foreignObject inside SVG gets the correct namespace: `http://www.w3.org/1999/xhtml` (the same behavior as React).

**Closes Issue**

It closes Issue #1087 

**Misc**

I added the failing test case in the `inferno-create-element`, but the code fixes were placed in `inferno` package, which seems a bit weird to me. Please let me know if the test should be somewhere else.

I've only added the foreignObject check to the `mount` function, should it be added somewhere else also? I've tested this fix in my application it seems to behave as desired.