### PR TITLE
Fix package.json "typings" path

### DIFF
--- a/scripts/typings/build.js
+++ b/scripts/typings/build.js
@@ -17,7 +17,7 @@ try {
       "src/index.d.ts"
     ),
     name: pkgJSON.name,
-    out: join(cwd, `dist/${pkgJSON.name}.d.ts`)
+    out: join(cwd, `dist/index.d.ts`)
   });
   console.log(`${pkgJSON.name} in typings is DONE`);
 } catch (e) {


### PR DESCRIPTION
Currently, the package.json for individual inferno packages has a `typing` path pointing to a TypeScript types declaration file in `dist/index.d.ts`. However, the file is actually saved to `dist/${pkgJSON.name}.d.ts`. Either the `typing` path or the file name needs to be changed to resolve this mismatch.

This PR changes the file path.

 *Before* submitting a PR please:
 - Include tests for the functionality you are adding! See CONTRIBUTING.md for details how to run tests.
 - Make sure you have based your branch off the [dev branch](https://github.com/infernojs/inferno/tree/dev).
 - Submit your PR against the [dev branch](https://github.com/infernojs/inferno/tree/dev).
 - Run `npm run build` and check that the build succeeds.
 - Ensure that the PR hasn't been submitted before.

---

## PR Template

**Objective**

This PR...

**Closes Issue**

It closes Issue #...
