### PR TITLE
Fix package.json "typings" path

### DIFF
--- a/scripts/typings/build.js
+++ b/scripts/typings/build.js
@@ -17,7 +17,7 @@ try {
       "src/index.d.ts"
     ),
     name: pkgJSON.name,
-    out: join(cwd, `dist/${pkgJSON.name}.d.ts`)
+    out: join(cwd, `dist/index.d.ts`)
   });
   console.log(`${pkgJSON.name} in typings is DONE`);
 } catch (e) {


### PR DESCRIPTION
Currently, the package.json files for individual inferno packages have a `typings` path pointing to a TypeScript type declaration file in `dist/index.d.ts`. However, the type declaration files are actually being written to `dist/${pkgJSON.name}.d.ts`. 

To fix this, either the `typings` path or the file path need to be changed.

This PR changes the file path.