### PR TITLE
Allow async data fetching prior to performing transition

### DIFF
--- a/packages/inferno-router/README.md
+++ b/packages/inferno-router/README.md
@@ -209,6 +209,115 @@ Inferno.render((
 </Router>
 ```
 
+## Async Data Fetching
+To mimc standard browser behavior you want to fetch data before performing a transition. To
+achieve this you can use the `asyncBefore` hooks:
+
+```js
+        <Router history={browserHistory} asyncBefore={ /* user provided handler that resolves and calls route specific asyncBefore hooks */ }>
+          <Route path="/" asyncBefore={ /* route specific asyncBefore handler */ } component={ ... } />
+        </Router>
+```
+
+You will need some form of data store such as Mobx or Redux to propagate data to your component.
+
+### Pages and Routing
+
+```js
+  import Component from "inferno-component";
+
+  class PageOne extends Component {
+    static fetchData(params) {
+      return myDataFetcher() // Returns a promise
+    }
+
+    render() {
+      return <div>Page One <span>{dataStore.pageOne}</span></div>;
+    }
+  }
+
+  class PageTwo extends Component {
+    static fetchData(params) {
+      return myDataFetcher() // Returns a promise
+      });
+    }
+
+    render() {
+      return (
+        <div>Page Two <span>{dataStore.pageTwo}</span>{this.props.children}</div>
+      );
+    }
+  }
+
+  import { render } from "inferno";
+  import { Route, Router, match, doAllAsyncBefore } from "inferno-router";
+
+  const routes = (
+    <Router history={...} asyncBefore={
+      url => {
+        return doAllAsyncBefore(match(routes, url));
+      }
+    }>
+      <Route path="/" asyncBefore={PageOne.fetchData} component={PageOne} />
+      <Route path="/test" asyncBefore={PageTwo.fetchData} component={PageTwo} />
+    </Router>
+  );
+```
+
+### Render in Browser Without SSR
+
+```js
+  import { render } from "inferno";
+  import { match, doAllAsyncBefore } from "inferno-router";
+
+  // Need to prime the route props with data on first render
+  const renderProps = match(routes, "/");
+  doAllAsyncBefore(renderProps).then(() => {
+    // Then render
+    render(routes, document.getElementById('app'));
+  });
+```
+
+### Render in Browser WITH SSR
+```js
+  // Rehydrate state passed from server and then render...
+  if (typeof window !== 'undefined') {
+    render(routes, document.getElementById('app'));
+  }
+```
+
+### Server Side Rendering (SSR)
+This code will be executed in your server side controller and imports routes
+from app bundle. You need to pass the hydrated state to the client and rehydrate
+it before rendering.
+
+```js
+  import { RouterContext, match, doAllAsyncBefore } from "inferno-router";
+  import InfernoServer from "inferno-server";
+  import createElement from "inferno-create-element";
+
+  const renderProps = match(routes, "/");
+  doAllAsyncBefore(renderProps).then(() => {
+    const html = InfernoServer.renderToString(
+      createElement(RouterContext, renderProps)
+    );
+    
+    // Pass hydrated state (from Mobx or Redux) and rendered html to template
+  });
+```
+
+### Lifercycle of Route Transition
+
+1. onLeave
+2. asyncBefore (Router)
+3. -> asyncBefore (Route)
+4. render route
+5. onEnter
+
+### Adding a Progress Indicator
+To add a progress indicator you would initiate and terminate it in Router.props.asyncBefore hook.
+Actual progress would be updated in the route specific asyncBefore handler.
+
 ## Notes
 
 * `<IndexRoute>` is the same as `<Route path="/">"`

--- a/packages/inferno-router/README.md
+++ b/packages/inferno-router/README.md
@@ -210,7 +210,7 @@ Inferno.render((
 ```
 
 ## Async Data Fetching
-To mimc standard browser behavior you want to fetch data before performing a transition. To
+To mimic standard browser behavior you want to fetch data before performing a transition. To
 achieve this you can use the `asyncBefore` hooks:
 
 ```js
@@ -219,7 +219,7 @@ achieve this you can use the `asyncBefore` hooks:
         </Router>
 ```
 
-You will need some form of data store such as Mobx or Redux to propagate data to your component.
+You will need a data store such as Mobx or Redux to propagate data to your component.
 
 ### Pages and Routing
 

--- a/packages/inferno-router/__tests__/asyncBeforeBrowser.spec.jsx
+++ b/packages/inferno-router/__tests__/asyncBeforeBrowser.spec.jsx
@@ -1,0 +1,267 @@
+import { createMemoryHistory } from "history";
+import { render } from "inferno";
+import Component from "inferno-component";
+import { innerHTML } from "inferno-utils";
+import {
+  IndexRoute,
+  Link,
+  Route,
+  Router,
+  match,
+  doAllAsyncBefore
+} from "inferno-router";
+
+const browserHistory = createMemoryHistory();
+
+var dataStore = {};
+
+class PageOne extends Component {
+  static fetchData(params) {
+    return new Promise(function(resolve, reject) {
+      setTimeout(() => {
+        dataStore["pageOne"] = "data page one";
+        resolve();
+      }, 0);
+    });
+  }
+
+  render() {
+    return <div>Page One <span>{dataStore.pageOne}</span></div>;
+  }
+}
+
+class PageTwo extends Component {
+  static fetchData(params) {
+    // console.log('Fetch Data PageTwo');
+    return new Promise(function(resolve, reject) {
+      setTimeout(() => {
+        dataStore["pageTwo"] = "data page two";
+        resolve();
+      }, 0);
+    });
+  }
+
+  render() {
+    return (
+      <div>Page Two <span>{dataStore.pageTwo}</span>{this.props.children}</div>
+    );
+  }
+}
+
+class PageNoData extends Component {
+  static fetchData(params) {
+    return new Promise(function(resolve, reject) {
+      setTimeout(() => {
+        resolve();
+      }, 0);
+    });
+  }
+
+  render() {
+    return <div>Page No Data</div>;
+  }
+}
+
+class PageNoAsync extends Component {
+  render() {
+    return <div>Page No Async</div>;
+  }
+}
+
+class Section extends Component {
+  static fetchData(params) {
+    return new Promise(function(resolve, reject) {
+      setTimeout(() => {
+        dataStore["section"] = "data section";
+        resolve();
+      }, 0);
+    });
+  }
+
+  render() {
+    return <div>Section <span>{dataStore.section}</span></div>;
+  }
+}
+
+describe("Router (jsx) asyncBefore", () => {
+  describe("with browser rendering", () => {
+    let container;
+
+    beforeEach(function() {
+      dataStore = {};
+      browserHistory.push("/");
+      container = document.createElement("div");
+      document.body.appendChild(container);
+    });
+
+    afterEach(function() {
+      render(null, container);
+      document.body.removeChild(container);
+    });
+
+    it("should resolve single asyncBefore", done => {
+      function didEnter() {
+        requestAnimationFrame(() => {
+          expect(innerHTML(container.innerHTML)).toBe(
+            innerHTML("<div>Page One <span>data page one</span></div>")
+          );
+          done();
+        });
+      }
+
+      const routes = (
+        <Router history={browserHistory}>
+          <Route
+            key="test"
+            path={"/"}
+            asyncBefore={PageOne.fetchData}
+            onEnter={didEnter}
+            component={PageOne}
+          />
+        </Router>
+      );
+
+      // Need to prime the route props with data on first render. With SSR this should be done by hydration
+      // so makes sense not to perform automagically in router.
+      const renderProps = match(routes, "/");
+      doAllAsyncBefore(renderProps).then(() => {
+        // Then render
+        render(routes, container);
+      });
+    });
+
+    it("should resolve nested asyncBefore", done => {
+      function didEnter() {
+        requestAnimationFrame(() => {
+          expect(innerHTML(container.innerHTML)).toBe(
+            innerHTML(
+              "<div>Page Two <span>data page two</span><div>Section <span>data section</span></div></div>"
+            )
+          );
+          done();
+        });
+      }
+
+      const routes = (
+        <Router history={browserHistory}>
+          <Route path="/" asyncBefore={PageTwo.fetchData} component={PageTwo}>
+            <Route
+              asyncBefore={Section.fetchData}
+              onEnter={didEnter}
+              component={Section}
+            />
+          </Route>
+        </Router>
+      );
+
+      const renderProps = match(routes, "/");
+      doAllAsyncBefore(renderProps).then(() => {
+        // Then render
+        render(routes, container);
+      });
+    });
+
+    it("should render without asyncBefore provided", done => {
+      function didEnter() {
+        requestAnimationFrame(() => {
+          expect(innerHTML(container.innerHTML)).toBe(
+            innerHTML("<div>Page No Async</div>")
+          );
+          done();
+        });
+      }
+
+      const routes = (
+        <Router history={browserHistory}>
+          <Route path="/" component={PageNoAsync} onEnter={didEnter} />
+        </Router>
+      );
+
+      const renderProps = match(routes, "/");
+      doAllAsyncBefore(renderProps).then(() => {
+        // Then render
+        render(routes, container);
+      });
+    });
+
+    it("should handle navigation", done => {
+      class TransientPageOne extends Component {
+        static fetchData(params) {
+          return new Promise(function(resolve, reject) {
+            setTimeout(() => {
+              dataStore["pageOne"] = "data page one";
+              resolve();
+            }, 0);
+          });
+        }
+
+        componentDidMount() {
+          requestAnimationFrame(() => {
+            requestAnimationFrame(() => {
+              // console.log('push')
+              this.context.router.push("/test3");
+            });
+          });
+        }
+
+        render() {
+          return <div>Page One <span>{dataStore.pageOne}</span></div>;
+        }
+      }
+
+      function didEnterOne() {
+        // console.log('Step 1.1')
+        requestAnimationFrame(() => {
+          // console.log('Step 1.2')
+          expect(innerHTML(container.innerHTML)).toBe(
+            innerHTML("<div>Page One <span>data page one</span></div>")
+          );
+          // console.log('Step 1.3')
+        });
+      }
+
+      function didEnterTwo() {
+        // console.log('Step 2.1')
+        requestAnimationFrame(() => {
+          // console.log('Step 2.2')
+          expect(innerHTML(container.innerHTML)).toBe(
+            innerHTML("<div>Page Two <span>data page two</span></div>")
+          );
+          // console.log('Step 2.3')
+          done();
+        });
+      }
+
+      const routes = (
+        <Router
+          history={browserHistory}
+          asyncBefore={url => {
+            // console.log('Async before...')
+            return doAllAsyncBefore(match(routes, url));
+          }}
+        >
+          <Route
+            path="/"
+            asyncBefore={TransientPageOne.fetchData}
+            onEnter={didEnterOne}
+            component={TransientPageOne}
+          />
+          <Route
+            path="/test3"
+            asyncBefore={PageTwo.fetchData}
+            onEnter={didEnterTwo}
+            component={PageTwo}
+          />
+        </Router>
+      );
+
+      // Need to prime the route props with data on first render. With SSR this should be done by hydration
+      // so makes sense not to perform automagically in router.
+      const renderProps = match(routes, "/");
+      doAllAsyncBefore(renderProps).then(() => {
+        // Then render
+        render(routes, container);
+      });
+    });
+  });
+});

--- a/packages/inferno-router/__tests__/asyncBeforeServer.spec.jsx
+++ b/packages/inferno-router/__tests__/asyncBeforeServer.spec.jsx
@@ -1,0 +1,176 @@
+import { createMemoryHistory } from "history";
+import { render } from "inferno";
+import Component from "inferno-component";
+import InfernoServer from "inferno-server";
+import createElement from "inferno-create-element";
+import { innerHTML } from "inferno-utils";
+import {
+  IndexRoute,
+  Link,
+  Route,
+  Router,
+  RouterContext,
+  match,
+  doAllAsyncBefore
+} from "inferno-router";
+
+const browserHistory = createMemoryHistory();
+
+var dataStore = {};
+
+class PageOne extends Component {
+  static fetchData(params) {
+    return new Promise(function(resolve, reject) {
+      setTimeout(() => {
+        dataStore["pageOne"] = "data page one";
+        resolve();
+      }, 0);
+    });
+  }
+
+  render() {
+    return <div>Page One <span>{dataStore.pageOne}</span></div>;
+  }
+}
+
+class PageTwo extends Component {
+  static fetchData(params) {
+    return new Promise(function(resolve, reject) {
+      setTimeout(() => {
+        dataStore["pageTwo"] = "data page two";
+        resolve();
+      }, 0);
+    });
+  }
+
+  render() {
+    return (
+      <div>Page Two <span>{dataStore.pageTwo}</span>{this.props.children}</div>
+    );
+  }
+}
+
+class PageNoData extends Component {
+  static fetchData(params) {
+    return new Promise(function(resolve, reject) {
+      setTimeout(() => {
+        resolve();
+      }, 0);
+    });
+  }
+
+  render() {
+    return <div>Page No Data</div>;
+  }
+}
+
+class PageNoAsync extends Component {
+  render() {
+    return <div>Page No Async</div>;
+  }
+}
+
+class Section extends Component {
+  static fetchData(params) {
+    return new Promise(function(resolve, reject) {
+      setTimeout(() => {
+        dataStore["section"] = "data section";
+        resolve();
+      }, 0);
+    });
+  }
+
+  render() {
+    return <div>Section <span>{dataStore.section}</span></div>;
+  }
+}
+
+describe("Router (jsx) asyncBefore", () => {
+  beforeEach(function() {
+    dataStore = {};
+  });
+
+  describe("with	SSR", () => {
+    it("should resolve single asyncBefore", done => {
+      const routes = (
+        <Router history={browserHistory}>
+          <Route path="/" asyncBefore={PageOne.fetchData} component={PageOne} />
+        </Router>
+      );
+
+      const renderProps = match(routes, "/");
+      doAllAsyncBefore(renderProps).then(() => {
+        const html = InfernoServer.renderToString(
+          createElement(RouterContext, renderProps)
+        );
+        expect(html).toBe(
+          innerHTML("<div>Page One <span>data page one</span></div>")
+        );
+        done();
+      });
+    });
+
+    it("should resolve nested asyncBefore", done => {
+      const routes = (
+        <Router history={browserHistory}>
+          <Route path="/" asyncBefore={PageTwo.fetchData} component={PageTwo}>
+            <Route asyncBefore={Section.fetchData} component={Section} />
+          </Route>
+        </Router>
+      );
+
+      const renderProps = match(routes, "/");
+      doAllAsyncBefore(renderProps).then(() => {
+        const html = InfernoServer.renderToString(
+          createElement(RouterContext, renderProps)
+        );
+        expect(html).toBe(
+          innerHTML(
+            "<div>Page Two <span>data page two</span><div>Section <span>data section</span></div></div>"
+          )
+        );
+        done();
+      });
+    });
+
+    it("should resolve multiple nested asyncBefore", done => {
+      const routes = (
+        <Router history={browserHistory}>
+          <Route path="/" asyncBefore={PageTwo.fetchData} component={PageTwo}>
+            <Route asyncBefore={Section.fetchData} component={Section} />
+          </Route>
+        </Router>
+      );
+
+      const renderProps = match(routes, "/");
+      doAllAsyncBefore(renderProps).then(() => {
+        const html = InfernoServer.renderToString(
+          createElement(RouterContext, renderProps)
+        );
+        expect(html).toBe(
+          innerHTML(
+            "<div>Page Two <span>data page two</span><div>Section <span>data section</span></div></div>"
+          )
+        );
+        done();
+      });
+    });
+
+    it("should render without asyncBefore provided", done => {
+      const routes = (
+        <Router history={browserHistory}>
+          <Route path="/" component={PageNoAsync} />
+        </Router>
+      );
+
+      const renderProps = match(routes, "/");
+      doAllAsyncBefore(renderProps).then(() => {
+        const html = InfernoServer.renderToString(
+          createElement(RouterContext, renderProps)
+        );
+        expect(html).toBe(innerHTML("<div>Page No Async</div>"));
+        done();
+      });
+    });
+  });
+});

--- a/packages/inferno-router/src/Route.ts
+++ b/packages/inferno-router/src/Route.ts
@@ -16,6 +16,7 @@ export interface IRouteProps {
   params?: any;
   onEnter?: IRouteHook;
   onLeave?: IRouteHook;
+  asyncBefore?: any;
   path: string;
   children: Array<Component<any, any>>;
   component?: Component<any, any>;
@@ -56,6 +57,14 @@ export default class Route extends Component<IRouteProps, any> {
       asyncComponent: component
     });
   };
+
+  public doAsyncBefore(params) {
+    if (this.props.asyncBefore) {
+      return this.props.asyncBefore(params);
+    } else {
+      return Promise.resolve();
+    }
+  }
 
   public onLeave(trigger = false) {
     const { onLeave } = this.props;

--- a/packages/inferno-router/src/Router.ts
+++ b/packages/inferno-router/src/Router.ts
@@ -15,6 +15,7 @@ export interface IRouterProps {
   location: any;
   baseUrl?: any;
   component?: Component<any, any>;
+  asyncBefore?: any;
   onUpdate?: any;
 }
 
@@ -61,7 +62,14 @@ export default class Router extends Component<IRouterProps, any> {
   public componentWillMount() {
     if (this.router) {
       this.unlisten = this.router.listen(() => {
-        this.routeTo(this.router.url);
+        if (typeof this.props.asyncBefore === "function") {
+          const self = this;
+          this.props.asyncBefore(this.router.url).then(() => {
+            self.routeTo(self.router.url);
+          });
+        } else {
+          this.routeTo(this.router.url);
+        }
       });
     }
   }

--- a/packages/inferno-router/src/doAllAsyncBefore.ts
+++ b/packages/inferno-router/src/doAllAsyncBefore.ts
@@ -1,0 +1,21 @@
+export default function doAllAsyncBefore(renderProps) {
+  const promises: Object[] = [];
+
+  const getAsyncBefore = function(root) {
+    if (root) {
+      if (root.props && root.props.children) {
+        getAsyncBefore(root.props.children);
+      }
+
+      if (root.type.name === "Route" && root.props.asyncBefore) {
+        // Resolve asyncBefore
+        promises.push(
+          root.type.prototype.doAsyncBefore.call(root, root.props.params)
+        );
+      }
+    }
+  };
+
+  getAsyncBefore(renderProps.matched);
+  return Promise.all(promises).then(() => Promise.resolve(true));
+}

--- a/packages/inferno-router/src/index.ts
+++ b/packages/inferno-router/src/index.ts
@@ -4,6 +4,7 @@
 
 import { VNode } from "inferno";
 import createRoutes, { IPlainRouteConfig } from "./createRoutes";
+import doAllAsyncBefore from "./doAllAsyncBefore";
 import IndexLink from "./IndexLink";
 import IndexRoute from "./IndexRoute";
 import Link from "./Link";
@@ -25,6 +26,7 @@ export {
   RouterContext,
   VNode,
   createRoutes,
+  doAllAsyncBefore,
   match
 };
 
@@ -38,5 +40,6 @@ export default {
   Router,
   RouterContext,
   createRoutes,
+  doAllAsyncBefore,
   match
 };


### PR DESCRIPTION
**Objective**

Add support for async data fetching prior to performing transitions in router. The purpose of asyncBefore is to maintain standard browser behaviour when navigating between pages. 

Unlike getComponent this allows all the matched fetchers to resolve concurrently. The attribute name (asyncBefore) also makes the router declarations more readable.

I have added tests and updated the docs.

**Closes Issue**

It closes Issue #1045 
