### PR TITLE
Fix DOM option "value" rendering

### DIFF
--- a/packages/inferno-server/__tests__/creation.spec.jsx
+++ b/packages/inferno-server/__tests__/creation.spec.jsx
@@ -80,7 +80,7 @@ describe("SSR Creation (JSX)", () => {
           <option value="dog">A dog</option>
         </select>,
       result:
-        '<select value="dog"><option>A cat</option><option selected>A dog</option></select>'
+        '<select value="dog"><option value="cat">A cat</option><option value="dog" selected>A dog</option></select>'
     },
     {
       description: "should render a text placeholder",

--- a/packages/inferno-server/src/renderToString.ts
+++ b/packages/inferno-server/src/renderToString.ts
@@ -98,11 +98,6 @@ function renderVNodeToString(
           if (!props.checked) {
             renderedString += ` checked="${value}"`;
           }
-        } else if (type === "option" && prop === "value") {
-          // Parent value sets children value
-          if (value === parent.props.value) {
-            renderedString += ` selected`;
-          }
         } else {
           if (isString(value)) {
             renderedString += ` ${prop}="${escapeText(value)}"`;
@@ -112,6 +107,10 @@ function renderVNodeToString(
             renderedString += ` ${prop}`;
           }
         }
+      }
+      if (type === "option" && typeof props.value !== "undefined" && props.value === parent.props.value) {
+        // Parent value sets children value
+        renderedString += ` selected`;
       }
     }
     if (isVoidElement) {


### PR DESCRIPTION
```
class Select extends Component {
  render() {
    return (
      <select class="form-control" id={this.props.id} name={this.props.name}>
        {this.props.options.map((option) => (
          <option value={option.value}>{option.text}</option>
        ))}
      </select>
    )
  }
}
```
"value" props is not rendered in renderVNodeToString()

Please see the PR code.
