### PR TITLE
fix(Component.setState{,Sync}): specify exact type of `newState`

### DIFF
--- a/packages/inferno-component/src/index.ts
+++ b/packages/inferno-component/src/index.ts
@@ -294,7 +294,7 @@ export default class Component<P, S> implements ComponentLifecycle<P, S> {
     applyState(this, true, callback);
   }
 
-  public setState(newState, callback?: Function) {
+  public setState(newState: S, callback?: Function) {
     if (this._unmounted) {
       return;
     }
@@ -310,7 +310,7 @@ export default class Component<P, S> implements ComponentLifecycle<P, S> {
     }
   }
 
-  public setStateSync(newState) {
+  public setStateSync(newState: S) {
     if (process.env.NODE_ENV !== "production") {
       if (!alreadyWarned) {
         alreadyWarned = true;


### PR DESCRIPTION
**Objective**

This PR adds a type for the `newState` argument to `Component.setState` and `Component.setStateSync` functions. Not specifying a type was resulting in the TypeScript definition having the type `newState: any`.

**Closes Issue**

There is no issue.

--

I'm new to TypeScript, please let me know if I got anything wrong!