### PR TITLE
Fix escapeText method for any value (#1196)

### DIFF
--- a/packages/inferno-server/__tests__/creation.spec.jsx
+++ b/packages/inferno-server/__tests__/creation.spec.jsx
@@ -90,6 +90,11 @@ describe("SSR Creation (JSX)", () => {
       result: '<input value="foo">'
     },
     {
+      description: "should render input when defaultValue is number",
+      template: () => <input defaultValue={123} />,
+      result: '<input value="123">'
+    },
+    {
       description:
         "should render input of type text with value when input is wrapped",
       template: () => <WrappedInput value="foo" />,

--- a/packages/inferno-server/src/utils.ts
+++ b/packages/inferno-server/src/utils.ts
@@ -2,7 +2,12 @@
  * @module Inferno-Server
  */ /** TypeDoc Comment */
 
-export function escapeText(text: string): string {
+import { isString } from "inferno-shared";
+
+export function escapeText(text: any): string {
+  if (!isString(text)) {
+    text = text + "";
+  }
   let result = "";
   let escape = "";
   let start = 0;

--- a/packages/inferno-server/src/utils.ts
+++ b/packages/inferno-server/src/utils.ts
@@ -4,10 +4,17 @@
 
 import { isString } from "inferno-shared";
 
+const rxUnescaped = /["'&<>]/;
 export function escapeText(text: any): string {
   if (!isString(text)) {
     text = text + "";
   }
+
+  /* Much faster when there is no unescaped characters */
+  if (!rxUnescaped.test(text)) {
+    return text;
+  }
+
   let result = "";
   let escape = "";
   let start = 0;
@@ -17,7 +24,7 @@ export function escapeText(text: any): string {
       case 34: // "
         escape = "&quot;";
         break;
-      case 39: // \
+      case 39: // '
         escape = "&#039;";
         break;
       case 38: // &
@@ -33,11 +40,7 @@ export function escapeText(text: any): string {
         continue;
     }
     if (i > start) {
-      if (start) {
-        result += text.slice(start, i);
-      } else {
-        result = text.slice(start, i);
-      }
+      result += text.slice(start, i);
     }
     result += escape;
     start = i + 1;


### PR DESCRIPTION
Fixed issue with escaping numbers in SSR (#1196) and added test

Added optimization for escaping strings without unescaped characters (most popular case) 
