### PR TITLE
Add jsDelivr link

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,12 @@ npm install --save inferno-router
 
 Pre-bundled files for browser consumption can be found on [our cdnjs](https://cdnjs.com/libraries/inferno):
 
+Or on jsDelivr:
+
+```
+https://cdn.jsdelivr.net/npm/inferno@latest/dist/inferno.min.js
+```
+
 Or on unpkg.com:
 
 ```


### PR DESCRIPTION
I added [jsDelivr CDN links](https://www.jsdelivr.com/package/npm/inferno) to your readme as an alternative to unpkg. jsDelivr is also the [fastest opensource CDN](https://www.cdnperf.com/) available and built specifically for production usage. It can serve any project from npm with zero config just like unpkg.