### PR TITLE
state isn't mutated without pending changes

### DIFF
--- a/packages/inferno-shared/src/index.ts
+++ b/packages/inferno-shared/src/index.ts
@@ -76,6 +76,9 @@ export function warning(message: string) {
 }
 
 export function combineFrom(first?: {} | null, second?: {} | null): object {
+  if (first === null || second === null) {
+    return first || second || {};
+  }
   const out = {};
   if (first) {
     for (const key in first) {

--- a/packages/inferno/__tests__/setState.spec.jsx
+++ b/packages/inferno/__tests__/setState.spec.jsx
@@ -130,6 +130,40 @@ describe("setState", () => {
     render(<BaseComp />, container);
   });
 
+  it("Should let state be an array after update", () => {
+    class TestComponent extends Component {
+      constructor(props) {
+        super(props);
+        this.state = [ 'a', 'b' ];
+      }
+
+      componentWillReceiveProps(nextProps) {
+        this.state = [ 'a', 'b' ];
+      }
+
+      render() {
+        return null;
+      }
+    }
+
+    class BaseComp extends Component {
+      state = ["__OLDVALUE__"];
+
+      componentDidMount() {
+        this.state = ["__NEWVALUE__"];
+      }
+
+      render() {
+        expect(this.state instanceof Array).toBeTruthy();
+        expect(this.state.length).toBe(1);
+        const value = this.state[0];
+        return <TestComponent value={value} />;
+      }
+    }
+
+    render(<BaseComp />, container);
+  });
+
   // Should work as Per react: https://jsfiddle.net/f12u8xzb/
   // React does not get stuck
   it("Should not get stuck in infinite loop #1", done => {


### PR DESCRIPTION
**Objective**

This PR allows setting `this.state = [];` and maintaining state as an array as-long-as setState isn't called.

**Closes Issue**

It closes Issue #1228
