### PR TITLE
Passing root context via render() or options

### DIFF
--- a/packages/inferno/__tests__/componentlifecycle.spec.jsx
+++ b/packages/inferno/__tests__/componentlifecycle.spec.jsx
@@ -1,4 +1,4 @@
-import { Component, render } from "inferno";
+import { Component, render, options } from "inferno";
 import { innerHTML } from "inferno-utils";
 
 describe("Component lifecycle", () => {
@@ -193,5 +193,37 @@ describe("Component lifecycle", () => {
 
     // eslint-disable-next-line no-return-assign
     render(<Com ref={inst => (c = inst)} value={2} />, container);
+  });
+
+  it("Should pass defaultContext to constructor", () => {
+    options.defaultContext = { value: 1 };
+
+    class Com extends Component {
+      constructor(props, context) {
+        super(props, context);
+        expect(context.value).toBe(1);
+      }
+
+      render() {
+        return <div>{this.context.value}</div>;
+      }
+    }
+
+    render(<Com />, container);
+  });
+
+  it("Should pass render context param to constructor", () => {
+    class Com extends Component {
+      constructor(props, context) {
+        super(props, context);
+        expect(context.value).toBe(1);
+      }
+
+      render() {
+        return <div>{this.context.value}</div>;
+      }
+    }
+
+    render(<Com />, container, null, { value: 1 });
   });
 });

--- a/packages/inferno/src/DOM/hydration.ts
+++ b/packages/inferno/src/DOM/hydration.ts
@@ -267,7 +267,7 @@ function hydrate(
   }
 }
 
-export function hydrateRoot(input, parentDom: Element, lifecycle: Function[], context: Object = EMPTY_OBJ) {
+export function hydrateRoot(input, parentDom: Element, lifecycle: Function[], context: Object) {
   let dom = parentDom.firstChild as Element;
 
   if (!isNull(dom)) {

--- a/packages/inferno/src/DOM/hydration.ts
+++ b/packages/inferno/src/DOM/hydration.ts
@@ -267,11 +267,11 @@ function hydrate(
   }
 }
 
-export function hydrateRoot(input, parentDom: Element, lifecycle: Function[]) {
+export function hydrateRoot(input, parentDom: Element, lifecycle: Function[], context: Object = EMPTY_OBJ) {
   let dom = parentDom.firstChild as Element;
 
   if (!isNull(dom)) {
-    hydrate(input, dom, lifecycle, EMPTY_OBJ, false);
+    hydrate(input, dom, lifecycle, context, false);
     dom = parentDom.firstChild as Element;
     // clear any other DOM nodes, there should be only a single entry for the root
     while ((dom = dom.nextSibling as Element)) {

--- a/packages/inferno/src/DOM/rendering.ts
+++ b/packages/inferno/src/DOM/rendering.ts
@@ -96,7 +96,8 @@ export function render(
     | null
     | HTMLElement
     | Node,
-  callback?: Function
+  callback?: Function,
+  context = getDefaultContext()
 ): InfernoChildren {
   // Development warning
   if (process.env.NODE_ENV !== "production") {
@@ -118,13 +119,13 @@ export function render(
       if ((input as VNode).dom) {
         input = directClone(input as VNode);
       }
-      if (!hydrateRoot(input, parentDom as any, lifecycle)) {
+      if (!hydrateRoot(input, parentDom as any, lifecycle, context)) {
         mount(
           input as VNode,
           parentDom as Element,
           lifecycle,
-          EMPTY_OBJ,
-          false
+          context,
+          false,
         );
       }
       root = setRoot(parentDom as any, input as VNode);
@@ -142,7 +143,7 @@ export function render(
         input as VNode,
         parentDom as Element,
         lifecycle,
-        EMPTY_OBJ,
+        context,
         false
       );
       root.input = input as VNode;
@@ -163,6 +164,10 @@ export function render(
       return rootInput.children;
     }
   }
+}
+
+function getDefaultContext() {
+  return typeof options.defaultContext === 'function' ? options.defaultContext() : (options.defaultContext || EMPTY_OBJ);
 }
 
 export function createRenderer(parentDom?) {

--- a/packages/inferno/src/core/implementation.ts
+++ b/packages/inferno/src/core/implementation.ts
@@ -546,6 +546,7 @@ export const options: {
   beforeRender: null | Function;
   beforeUnmount: null | Function;
   createVNode: null | Function;
+  defaultContext: null | Object | Function;
   findDOMNodeEnabled: boolean;
   roots: Root[];
 } = {
@@ -555,6 +556,7 @@ export const options: {
   beforeRender: null,
   beforeUnmount: null,
   createVNode: null,
+  defaultContext: null,
   findDOMNodeEnabled: false,
   roots: []
 };


### PR DESCRIPTION
## PR Template

**Objective**

This PR gives a way to pass context to a root element

**Closes Issue**

It closes Issue #1222
