### PR TITLE
Fix bug in minified build where asyncBefore functions weren't called

### DIFF
--- a/packages/inferno-mobx/src/Provider.ts
+++ b/packages/inferno-mobx/src/Provider.ts
@@ -20,7 +20,7 @@ export default class Provider extends Component<any, any> {
     // tslint:disable-next-line:no-empty
     mobxStores() {}
   };
-  private store: any;
+  public store: any;
 
   constructor(props?: any, context?: any) {
     super(props, context);

--- a/packages/inferno-redux/src/components/connectAdvanced.ts
+++ b/packages/inferno-redux/src/components/connectAdvanced.ts
@@ -170,7 +170,7 @@ export function connectAdvanced(
       public static displayName = displayName;
       public static WrappedComponent = WrappedComponent;
 
-      private version: number;
+      public version: number;
       private renderCount: number;
       private propsMode: boolean;
       private store: Store<any> | null;

--- a/packages/inferno-redux/src/connect/connect.ts
+++ b/packages/inferno-redux/src/connect/connect.ts
@@ -79,14 +79,14 @@ export const createConnect = (
     shouldHandleStateChanges: !!mapStateToProps,
 
     // passed through to selectorFactory
-    initMapStateToProps,
-    initMapDispatchToProps,
-    initMergeProps,
-    pure,
-    areStatesEqual,
+    areMergedPropsEqual,
     areOwnPropsEqual,
     areStatePropsEqual,
-    areMergedPropsEqual,
+    areStatesEqual,
+    initMapDispatchToProps,
+    initMapStateToProps,
+    initMergeProps,
+    pure,
 
     // any extra options args can override defaults of connect or connectAdvanced
     ...extraOptions

--- a/packages/inferno-router/src/doAllAsyncBefore.ts
+++ b/packages/inferno-router/src/doAllAsyncBefore.ts
@@ -2,16 +2,13 @@ export default function doAllAsyncBefore(renderProps) {
   const promises: Object[] = [];
 
   const getAsyncBefore = function(root) {
-    if (root) {
-      if (root.props && root.props.children) {
-        getAsyncBefore(root.props.children);
+    if (root && root.props) {
+      if (root.props.children) {
+          getAsyncBefore(root.props.children);
       }
-
-      if (root.type.name === "Route" && root.props.asyncBefore) {
-        // Resolve asyncBefore
-        promises.push(
-          root.type.prototype.doAsyncBefore.call(root, root.props.params)
-        );
+      if (typeof root.props.asyncBefore === 'function' && root.type.prototype.doAsyncBefore) {
+          // Resolve asyncBefore
+          promises.push(root.type.prototype.doAsyncBefore.call(root, root.props.params));
       }
     }
   };


### PR DESCRIPTION
A conditional check failed because of function renaming in minified builds. This prevented asyncBefore calls to work properly using the provided convenience method in production.

Also fixed some typescript errors.