### PR TITLE
Fix issue with runtime error in devtools when instance is null

### DIFF
--- a/packages/inferno-devtools/src/bridge.ts
+++ b/packages/inferno-devtools/src/bridge.ts
@@ -357,13 +357,13 @@ function createReactCompositeComponent(vNode, isFirstCreation) {
       return typeName(type);
     },
     node: dom,
-    props: instance.props,
-    setState: instance.setState.bind(instance),
-    state: instance.state,
+    props: instance && instance.props,
+    setState: instance && instance.setState && instance.setState.bind(instance),
+    state: instance && instance.state,
     vNode
   };
 
-  if (isFirstCreation) {
+  if (isFirstCreation && instance && instance.forceUpdate) {
     const forceInstanceUpdate = instance.forceUpdate.bind(instance); // Save off for use below.
     instance.forceUpdate = () => {
       instance.props = vNode.props = Object.assign(


### PR DESCRIPTION
Tested with inferno-formlib browser test page that broke with devtools activated

From slack:
https://infernojs.slack.com/archives/C0AEW144Q/p1513068742000491
https://infernojs.slack.com/archives/C0AEW144Q/p1513099645000390