### PR TITLE
rename inferno:main -> module in pkg file

### DIFF
--- a/packages/inferno-clone-vnode/package.json
+++ b/packages/inferno-clone-vnode/package.json
@@ -12,7 +12,7 @@
   },
   "homepage": "https://github.com/infernojs/inferno#readme",
   "main": "index.js",
-  "inferno:main": "dist/index.es.js",
+  "module": "dist/index.es.js",
   "typings": "dist/index.d.ts",
   "keywords": [
     "babel",

--- a/packages/inferno-compat/package.json
+++ b/packages/inferno-compat/package.json
@@ -12,7 +12,7 @@
   },
   "homepage": "https://github.com/infernojs/inferno#readme",
   "main": "index.js",
-  "inferno:main": "dist/index.es.js",
+  "module": "dist/index.es.js",
   "typings": "dist/index.d.ts",
   "keywords": [
     "babel",

--- a/packages/inferno-create-class/package.json
+++ b/packages/inferno-create-class/package.json
@@ -12,7 +12,7 @@
   },
   "homepage": "https://github.com/infernojs/inferno#readme",
   "main": "index.js",
-  "inferno:main": "dist/index.es.js",
+  "module": "dist/index.es.js",
   "typings": "dist/index.d.ts",
   "keywords": [
     "babel",

--- a/packages/inferno-create-element/package.json
+++ b/packages/inferno-create-element/package.json
@@ -12,7 +12,7 @@
   },
   "homepage": "https://github.com/infernojs/inferno#readme",
   "main": "index.js",
-  "inferno:main": "dist/index.es.js",
+  "module": "dist/index.es.js",
   "typings": "dist/index.d.ts",
   "keywords": [
     "babel",

--- a/packages/inferno-devtools/package.json
+++ b/packages/inferno-devtools/package.json
@@ -12,7 +12,7 @@
   },
   "homepage": "https://github.com/infernojs/inferno#readme",
   "main": "index.js",
-  "inferno:main": "dist/index.es.js",
+  "module": "dist/index.es.js",
   "typings": "dist/index.d.ts",
   "keywords": [
     "babel",

--- a/packages/inferno-hyperscript/package.json
+++ b/packages/inferno-hyperscript/package.json
@@ -9,7 +9,7 @@
   },
   "homepage": "https://github.com/infernojs/inferno#readme",
   "main": "index.js",
-  "inferno:main": "dist/index.es.js",
+  "module": "dist/index.es.js",
   "typings": "dist/index.d.ts",
   "keywords": [
     "inferno",

--- a/packages/inferno-mobx/package.json
+++ b/packages/inferno-mobx/package.json
@@ -12,7 +12,7 @@
   },
   "homepage": "https://github.com/infernojs/inferno#readme",
   "main": "index.js",
-  "inferno:main": "dist/index.es.js",
+  "module": "dist/index.es.js",
   "typings": "dist/index.d.ts",
   "keywords": [
     "babel",

--- a/packages/inferno-redux/package.json
+++ b/packages/inferno-redux/package.json
@@ -12,7 +12,7 @@
   },
   "homepage": "https://github.com/infernojs/inferno#readme",
   "main": "index.js",
-  "inferno:main": "dist/index.es.js",
+  "module": "dist/index.es.js",
   "typings": "dist/index.d.ts",
   "keywords": [
     "babel",

--- a/packages/inferno-router/package.json
+++ b/packages/inferno-router/package.json
@@ -12,7 +12,7 @@
   },
   "homepage": "https://github.com/infernojs/inferno#readme",
   "main": "index.js",
-  "inferno:main": "dist/index.es.js",
+  "module": "dist/index.es.js",
   "typings": "dist/index.d.ts",
   "keywords": [
     "babel",

--- a/packages/inferno-server/package.json
+++ b/packages/inferno-server/package.json
@@ -26,7 +26,7 @@
     "rollup"
   ],
   "main": "index.js",
-  "inferno:main": "dist/index.es.js",
+  "module": "dist/index.es.js",
   "typings": "dist/index.d.ts",
   "repository": "https://github.com/infernojs/inferno",
   "peerDependencies": {

--- a/packages/inferno-shared/package.json
+++ b/packages/inferno-shared/package.json
@@ -12,7 +12,7 @@
   },
   "homepage": "https://github.com/infernojs/inferno#readme",
   "main": "index.js",
-  "inferno:main": "dist/index.es.js",
+  "module": "dist/index.es.js",
   "typings": "dist/index.d.ts",
   "keywords": [
     "inferno",

--- a/packages/inferno-test-utils/package.json
+++ b/packages/inferno-test-utils/package.json
@@ -40,7 +40,7 @@
     }
   },
   "main": "index.js",
-  "inferno:main": "dist/index.es.js",
+  "module": "dist/index.es.js",
   "typings": "dist/index.d.ts",
   "repository": "https://github.com/infernojs/inferno"
 }

--- a/packages/inferno-vnode-flags/package.json
+++ b/packages/inferno-vnode-flags/package.json
@@ -32,7 +32,7 @@
     "moduleName": "Inferno"
   },
   "main": "index.js",
-  "inferno:main": "dist/index.es.js",
+  "module": "dist/index.es.js",
   "typings": "dist/index.d.ts",
   "repository": "https://github.com/infernojs/inferno"
 }

--- a/packages/inferno/package.json
+++ b/packages/inferno/package.json
@@ -34,7 +34,7 @@
     "moduleName": "Inferno"
   },
   "main": "index.js",
-  "inferno:main": "dist/index.es.js",
+  "module": "dist/index.es.js",
   "typings": "dist/index.d.ts",
   "repository": "https://github.com/infernojs/inferno",
   "devDependencies": {


### PR DESCRIPTION
**Objective**

I've added back in the [pkg.module](https://github.com/rollup/rollup/wiki/pkg.module) key based off of the conversation in #1188. This will make it easier for bundlers to pick up the correct version to include in their bundle (in this case, the es6 file).

The reason for removing the `inferno:main` is that it's a non-standard way (well, _less_ standard) of doing the above. As v4 is a breaking change, we may as well tidy up the other key.

In the future, we'll need to look into moving the es6 file to [.mjs](https://github.com/nodejs/node-eps/blob/master/002-es-modules.md#32-determining-if-source-is-an-es-module) extension so node can pick it up..

**Closes Issue**

Closes issue #1188
