### PR TITLE
Fixed typo

### DIFF
--- a/packages/inferno-compat/src/index.ts
+++ b/packages/inferno-compat/src/index.ts
@@ -279,7 +279,7 @@ class PureComponent<P, S> extends Component<P, S> {
 class WrapperComponent<P, S> extends Component<P, S> {
   public getChildContext() {
     // tslint:disable-next-line
-    return this.props.contex;
+    return this.props.context;
   }
 
   public render(props) {


### PR DESCRIPTION
Fixed typo introduced by https://github.com/infernojs/inferno/commit/7718d8dcaf2476c18aa97cc6102ba2ae3435fdb4

Did a search in React repos and found no references to `this.props.contex` without 't'.