### PR TITLE
Fixing typing issue with onChange handler

### DIFF
--- a/packages/inferno/src/JSX.ts
+++ b/packages/inferno/src/JSX.ts
@@ -135,8 +135,8 @@ declare global {
       onBlurCapture?: FocusEventHandler<T>;
 
       // Form Events
-      onChange?: FormEventHandler<T>;
-      onChangeCapture?: FormEventHandler<T>;
+      onChange?: ChangeEventHandler<T>;
+      onChangeCapture?: ChangeEventHandler<T>;
       onInput?: FormEventHandler<T>;
       onInputCapture?: FormEventHandler<T>;
       onReset?: FormEventHandler<T>;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -37,6 +37,7 @@
 		"jsx": "preserve",
 		"noUnusedLocals": true,
 		"strictNullChecks": true,
+		"strictFunctionTypes": true,
 		"removeComments": false,
         "experimentalDecorators": true,
 		"rootDir": "."


### PR DESCRIPTION
**Objective**

This PR fixes a typing issue with onChange handler, which shows itself with a stricter Typescript config.