### PR TITLE
Fix typo in inferno-create-class example

### DIFF
--- a/packages/inferno-create-class/README.md
+++ b/packages/inferno-create-class/README.md
@@ -18,7 +18,7 @@ import { render } from 'inferno';
 const MyComponent = createClass({
 	displayName: 'MyComponent',
 	render: function() {
-		return <div>Hell world!</div>;
+		return <div>Hello, world!</div>;
 	}
 });
 


### PR DESCRIPTION
**Objective**

This PR makes the `inferno-create-class` example a bit more optimistic.