### PR TITLE
Fix typo in inferno-vnode-flags README

### DIFF
--- a/packages/inferno-vnode-flags/README.md
+++ b/packages/inferno-vnode-flags/README.md
@@ -27,7 +27,7 @@ npm install --save inferno-vnode-flags
 - `VNodeFlags.ReCreate` (JSX **$ReCreate**) always re-creates the vNode
 
 **VNodeFlags Masks:**
-- `VNodeFlags.FormElement` - Is from element
+- `VNodeFlags.FormElement` - Is form element
 - `VNodeFlags.Element` - Is vNode element
 - `VNodeFlags.Component` - Is vNode Component
 - `VNodeFlags.VNodeShape` - mask for defining type


### PR DESCRIPTION
**Objective**

This PR fixes a small typo in `inferno-vnode-flags` docs/README.