### PR TITLE
Convert some tests to TypeScript to test typings

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -12,7 +12,7 @@ module.exports = {
     usingJSDOM: true,
     usingJest: true
   },
-  moduleFileExtensions: ["ts", "js", "jsx", "json"],
+  moduleFileExtensions: ["ts", "tsx", "js", "jsx", "json"],
   moduleNameMapper: {
     "^inferno-router/utils": "<rootDir>/packages/inferno-router/src/utils",
     "^inferno(.*?)$": "<rootDir>/packages/inferno$1/src"
@@ -20,12 +20,12 @@ module.exports = {
   rootDir: __dirname,
   setupFiles: ["<rootDir>/scripts/test/requestAnimationFrame.ts"],
   testMatch: [
-    "<rootDir>/packages/*/__tests__/**/*spec.js?(x)",
-    "<rootDir>/packages/*/__tests__/**/*spec.server.js?(x)"
+    "<rootDir>/packages/*/__tests__/**/*spec.@(js|ts)?(x)",
+    "<rootDir>/packages/*/__tests__/**/*spec.server.@(js|ts)?(x)"
   ],
   transform: {
     "^.+\\.jsx?$": "babel-jest",
-    "^.+\\.tsx?$": "<rootDir>/node_modules/ts-jest/preprocessor.js"
+    "^.+\\.tsx?$": "typescript-babel-jest"
   },
   setupTestFrameworkScriptFile: require.resolve("./JEST-DEBUG.js")
 };

--- a/package.json
+++ b/package.json
@@ -122,9 +122,9 @@
     "rollup-plugin-typescript2": "0.12.0",
     "rollup-plugin-uglify": "^3.0.0",
     "sinon": "^4.4.6",
-    "ts-jest": "^22.4.1",
     "tslint": "^5.9.1",
     "tslint-config-prettier": "^1.10.0",
-    "typescript": "2.7.2"
+    "typescript": "2.7.2",
+    "typescript-babel-jest": "^1.0.5"
   }
 }

--- a/packages/inferno-compat/src/index.ts
+++ b/packages/inferno-compat/src/index.ts
@@ -153,7 +153,7 @@ function normalizeGenericProps(props) {
   }
 }
 
-function normalizeFormProps(name: string, props: Props | any) {
+function normalizeFormProps<P>(name: string, props: Props<P> | any) {
   if ((name === 'input' || name === 'textarea') && props.type !== 'radio' && props.onChange) {
     const type = props.type;
     let eventName;

--- a/packages/inferno-create-element/src/index.ts
+++ b/packages/inferno-create-element/src/index.ts
@@ -18,7 +18,7 @@ const componentHooks = {
  * @param {...{object}=} _children Optional children for virtual node
  * @returns {VNode} new virtual ndoe
  */
-export function createElement<T>(type: string | Function | Component<any, any>, props?: T & Props | null, ..._children: Array<InfernoChildren | any>): VNode {
+export function createElement<T>(type: string | Function | Component<any, any>, props?: T & Props<T> | null, ..._children: Array<InfernoChildren | any>): VNode {
   if (isInvalid(type) || isObject(type)) {
     throw new Error('Inferno Error: createElement() name parameter cannot be undefined, null, false or true, It must be a string, class or function.');
   }
@@ -40,7 +40,7 @@ export function createElement<T>(type: string | Function | Component<any, any>, 
     flags = getFlagsForElementVnode(type as string);
 
     if (!isNullOrUndef(props)) {
-      newProps = {} as T & Props;
+      newProps = {} as T & Props<T>;
 
       for (const prop in props) {
         if (prop === 'className' || prop === 'class') {
@@ -67,7 +67,7 @@ export function createElement<T>(type: string | Function | Component<any, any>, 
     }
 
     if (!isNullOrUndef(props)) {
-      newProps = {} as T & Props;
+      newProps = {} as T & Props<T>;
 
       for (const prop in props) {
         if ((componentHooks as any)[prop] !== void 0) {

--- a/packages/inferno-router/src/StaticRouter.ts
+++ b/packages/inferno-router/src/StaticRouter.ts
@@ -72,7 +72,7 @@ export class StaticRouter extends Component<IStaticRouterProps, any> {
     return createComponentVNode(VNodeFlags.ComponentClass, Router, {
       ...props,
       history
-    });
+    } as any); // TODO: check these props types!
   }
 }
 

--- a/packages/inferno/__tests__/componentlifecycle.spec.tsx
+++ b/packages/inferno/__tests__/componentlifecycle.spec.tsx
@@ -17,14 +17,14 @@ describe('Component lifecycle', () => {
 
   it('componentWillUpdate Should have nextProp in params and old variants in instance', () => {
     let callCount = 0;
-    class Com extends Component {
-      componentWillUpdate(nextProps, nextState) {
+    class Com extends Component<{value: number}> {
+      public componentWillUpdate(nextProps, nextState) {
         callCount++;
         expect(this.props.value).toBe(1);
         expect(nextProps.value).toBe(2);
       }
 
-      render() {
+      public render() {
         return <div>{this.props.value}</div>;
       }
     }
@@ -41,15 +41,16 @@ describe('Component lifecycle', () => {
 
   it('Current state in componentWillUpdate should not equal nextState if setState is called from componentWillReceiveProps', done => {
     let doSomething;
-    class Child extends Component {
+    class Child extends Component<{active: boolean}> {
+      public state = {
+        active: false
+      };
+
       constructor() {
         super();
-        this.state = {
-          active: false
-        };
       }
 
-      componentWillReceiveProps(nextProps) {
+      public componentWillReceiveProps(nextProps) {
         if (!this.props.active && nextProps.active) {
           this.setState({
             active: true
@@ -57,32 +58,33 @@ describe('Component lifecycle', () => {
         }
       }
 
-      componentWillUpdate(nextProps, nextState) {
+      public componentWillUpdate(nextProps, nextState) {
         expect(this.state.active).toBe(false);
         expect(nextState.active).toBe(true);
       }
 
-      render() {
+      public render() {
         return <div>{this.state.active ? 'true' : 'false'}</div>;
       }
     }
 
     class Parent extends Component {
+      public state = {
+        active: false
+      };
+
       constructor() {
         super();
-        this.state = {
-          active: false
-        };
         doSomething = this._setActive = this._setActive.bind(this);
       }
 
-      _setActive() {
+      public _setActive() {
         this.setState({
           active: true
         });
       }
 
-      render() {
+      public render() {
         return (
           <div>
             <Child active={this.state.active} />
@@ -101,8 +103,8 @@ describe('Component lifecycle', () => {
 
   it('shouldComponentUpdate Should have nextProp in params and old variants in instance', () => {
     let callCount = 0;
-    class Com extends Component {
-      shouldComponentUpdate(nextProps, nextState) {
+    class Com extends Component<{value: number}> {
+      public shouldComponentUpdate(nextProps, nextState) {
         callCount++;
         expect(this.props.value).toBe(1);
         expect(nextProps.value).toBe(2);
@@ -110,7 +112,7 @@ describe('Component lifecycle', () => {
         return true;
       }
 
-      render() {
+      public render() {
         return <div>{this.props.value}</div>;
       }
     }
@@ -126,8 +128,8 @@ describe('Component lifecycle', () => {
   });
 
   it('Should call componentWillUnmount before node is removed from DOM tree', () => {
-    class Parent extends Component {
-      render() {
+    class Parent extends Component<{foo: boolean}> {
+      public render() {
         if (this.props.foo) {
           return (
             <div>
@@ -146,15 +148,17 @@ describe('Component lifecycle', () => {
     }
 
     class Child extends Component {
-      componentWillUnmount() {
+      private element: Element;
+
+      public componentWillUnmount() {
         // verify its not removed from DOM tree yet.
-        expect(this.element.parentElement.parentElement).toBe(container);
+        expect(this.element.parentElement != null ? this.element.parentElement.parentElement : null).toBe(container);
       }
 
-      render() {
+      public render() {
         // eslint-disable-next-line
         return (
-          <div className="foobar" ref={el => (this.element = el)}>
+          <div className="foobar" ref={el => (this.element = el!)}>
             1
           </div>
         );
@@ -169,11 +173,12 @@ describe('Component lifecycle', () => {
   });
 
   it('Should not fail if componentDidUpdate is undefined #922', () => {
+    // @ts-ignore
     let callCount = 0;
-    let c = null;
+    let c;
 
-    class Com extends Component {
-      componentDidUpdate(nextProps, nextState) {
+    class Com extends Component<{value: number}> {
+      public componentDidUpdate(nextProps, nextState) {
         callCount++;
         expect(this.props.value).toBe(1);
         expect(nextProps.value).toBe(2);
@@ -181,13 +186,13 @@ describe('Component lifecycle', () => {
         return true;
       }
 
-      render() {
+      public render() {
         return <div>{this.props.value}</div>;
       }
     }
 
     // eslint-disable-next-line no-return-assign
-    render(<Com ref={inst => (c = inst)} value={1} />, container);
+    render(<Com ref={inst => {c = inst}} value={1} />, container);
 
     c.componentDidUpdate = undefined;
 

--- a/packages/inferno/__tests__/setState.spec.tsx
+++ b/packages/inferno/__tests__/setState.spec.tsx
@@ -27,16 +27,17 @@ describe('setState', () => {
   });
 
   it('callback should be fired after state has changed', done => {
-    class TestComponent extends Component {
+    class TestComponent extends Component<{value: string}> {
+      public state = {
+        value: this.props.value
+      };
+
       constructor(props) {
         super(props);
-        this.state = {
-          value: props.value
-        };
         this.checkSetState = this.checkSetState.bind(this);
       }
 
-      checkSetState() {
+      public checkSetState() {
         const value = this.state.value;
         expect(value).toBe('__NEWVALUE__');
         setTimeout(function() {
@@ -44,7 +45,7 @@ describe('setState', () => {
         }, 100);
       }
 
-      componentWillReceiveProps(nextProps) {
+      public componentWillReceiveProps(nextProps) {
         this.setState(
           {
             value: nextProps.value
@@ -53,23 +54,23 @@ describe('setState', () => {
         );
       }
 
-      render() {
+      public render() {
         return null;
       }
     }
 
     class BaseComp extends Component {
-      state = {
+      public state = {
         value: '__OLDVALUE__'
       };
 
-      componentDidMount() {
+      public componentDidMount() {
         this.setState({
           value: '__NEWVALUE__'
         });
       }
 
-      render() {
+      public render() {
         const value = this.state.value;
         return <TestComponent value={value} />;
       }
@@ -79,7 +80,7 @@ describe('setState', () => {
   });
 
   it('Should not fail if callback is object and not function ( invalid used scenario )', () => {
-    class TestComponent extends Component {
+    class TestComponent extends Component<{value: string}> {
       constructor(props) {
         super(props);
         this.state = {
@@ -87,32 +88,32 @@ describe('setState', () => {
         };
       }
 
-      componentWillReceiveProps(nextProps) {
+      public componentWillReceiveProps(nextProps) {
         this.setState(
           {
             value: nextProps.value
           },
-          { foo: 'bar' } // This should not break inferno
+          { foo: 'bar' } as any // This should not break inferno
         );
       }
 
-      render() {
+      public render() {
         return null;
       }
     }
 
     class BaseComp extends Component {
-      state = {
+      public state = {
         value: '__OLDVALUE__'
       };
 
-      componentDidMount() {
+      public componentDidMount() {
         this.setState({
           value: '__NEWVALUE__'
         });
       }
 
-      render() {
+      public render() {
         const value = this.state.value;
         return <TestComponent value={value} />;
       }
@@ -122,15 +123,16 @@ describe('setState', () => {
   });
 
   it('Should not fail if componentDidUpdate is not defined', done => {
-    class TestComponent extends Component {
+    class TestComponent extends Component<{value: string}> {
+      public state = {
+        value: this.props.value
+      };
+
       constructor(props) {
         super(props);
-        this.state = {
-          value: props.value
-        };
       }
 
-      checkSetState() {
+      public checkSetState() {
         const value = this.state.value;
         expect(value).toBe('__NEWVALUE__');
         setTimeout(function() {
@@ -138,7 +140,7 @@ describe('setState', () => {
         }, 100);
       }
 
-      componentWillReceiveProps(nextProps) {
+      public componentWillReceiveProps(nextProps) {
         this.setState(
           {
             value: nextProps.value
@@ -147,23 +149,23 @@ describe('setState', () => {
         );
       }
 
-      render() {
+      public render() {
         return null;
       }
     }
 
     class BaseComp extends Component {
-      state = {
+      public state = {
         value: '__OLDVALUE__'
       };
 
-      componentDidMount() {
+      public componentDidMount() {
         this.setState({
           value: '__NEWVALUE__'
         });
       }
 
-      render() {
+      public render() {
         const value = this.state.value;
         return <TestComponent value={value} />;
       }
@@ -178,31 +180,31 @@ describe('setState', () => {
     let doSomething;
 
     class Parent extends Component {
+      public state = {
+        active: false,
+        foo: 'b'
+      };
+
       constructor(props, context) {
         super(props, context);
-
-        this.state = {
-          active: false,
-          foo: 'b'
-        };
 
         this._setBar = this._setBar.bind(this);
         doSomething = this._setActive = this._setActive.bind(this);
       }
 
-      _setBar() {
+      private _setBar() {
         this.setState({
           foo: 'bar'
         });
       }
 
-      _setActive() {
+      private _setActive() {
         this.setState({
           active: true
         });
       }
 
-      render() {
+      public render() {
         return (
           <div>
             <div>{this.state.foo}</div>
@@ -212,18 +214,18 @@ describe('setState', () => {
       }
     }
 
-    class Child extends Component {
+    class Child extends Component<{foo: string, callback: () => void}> {
       constructor(props, context) {
         super(props, context);
       }
 
-      componentWillUpdate(nextProps) {
+      public componentWillUpdate(nextProps) {
         if (nextProps.foo !== 'bar') {
           this.props.callback();
         }
       }
 
-      render() {
+      public render() {
         return (
           <div>
             <div>{this.props.foo}</div>
@@ -246,31 +248,31 @@ describe('setState', () => {
     let doSomething;
 
     class Parent extends Component {
+      public state = {
+        active: false,
+        foo: 'b'
+      };
+
       constructor(props, context) {
         super(props, context);
-
-        this.state = {
-          active: false,
-          foo: 'b'
-        };
 
         this._setBar = this._setBar.bind(this);
         doSomething = this._setActive = this._setActive.bind(this);
       }
 
-      _setBar() {
+      public _setBar() {
         this.setState({
           foo: 'bar'
         });
       }
 
-      _setActive() {
+      public _setActive() {
         this.setState({
           active: true
         });
       }
 
-      render() {
+      public render() {
         return (
           <div>
             <div>{this.state.foo}</div>
@@ -282,12 +284,12 @@ describe('setState', () => {
       }
     }
 
-    class Child extends Component {
+    class Child extends Component<{foo: string, callback: () => void}> {
       constructor(props, context) {
         super(props, context);
       }
 
-      componentWillReceiveProps(nextProps) {
+      public componentWillReceiveProps(nextProps) {
         if (nextProps.foo !== 'bar') {
           this.setState({
             foo: 'bbaarr'
@@ -297,7 +299,7 @@ describe('setState', () => {
         }
       }
 
-      render() {
+      public render() {
         return (
           <div>
             <div>{this.props.foo}</div>
@@ -319,31 +321,31 @@ describe('setState', () => {
     let doSomething;
 
     class Parent extends Component {
+      public state = {
+        active: false,
+        foo: 'b'
+      };
+
       constructor(props, context) {
         super(props, context);
-
-        this.state = {
-          active: false,
-          foo: 'b'
-        };
 
         this._setBar = this._setBar.bind(this);
         doSomething = this._setActive = this._setActive.bind(this);
       }
 
-      _setBar() {
+      private _setBar() {
         this.setState({
           foo: 'bar'
         });
       }
 
-      _setActive() {
+      private  _setActive() {
         this.setState({
           active: true
         });
       }
 
-      render() {
+      public render() {
         return (
           <div>
             <Child foo={this.state.foo} callback={this._setActive} />
@@ -358,12 +360,12 @@ describe('setState', () => {
       return <div>{foo}</div>;
     }
 
-    class Child extends Component {
+    class Child extends Component<{foo: string, callback: () => void}> {
       constructor(props, context) {
         super(props, context);
       }
 
-      componentWillReceiveProps(nextProps) {
+      public componentWillReceiveProps(nextProps) {
         if (nextProps.foo !== 'bar') {
           this.setState({
             foo: 'bbaarr'
@@ -373,7 +375,7 @@ describe('setState', () => {
         }
       }
 
-      render() {
+      public render() {
         return (
           <div>
             <div>{this.props.foo}</div>
@@ -394,23 +396,23 @@ describe('setState', () => {
     let changeFoo;
 
     class Parent extends Component {
+      public state = {
+        foo: 'bar'
+      };
+
       constructor(props, context) {
         super(props, context);
-
-        this.state = {
-          foo: 'bar'
-        };
 
         changeFoo = this.changeFoo.bind(this);
       }
 
-      changeFoo() {
+      public changeFoo() {
         this.setState({
           foo: 'bar2'
         });
       }
 
-      render() {
+      public render() {
         return (
           <div>
             <Child foo={this.state.foo} />
@@ -419,21 +421,21 @@ describe('setState', () => {
       }
     }
 
-    class Child extends Component {
+    class Child extends Component<{foo: string}> {
+      public state = {
+        foo: this.props.foo
+      };
+
       constructor(props, context) {
         super(props, context);
-
-        this.state = {
-          foo: props.foo
-        };
       }
 
-      callback() {
+      public callback() {
         expect(container.firstChild.firstChild.innerHTML).toBe('bar2');
         done();
       }
 
-      componentWillReceiveProps(nextProps) {
+      public componentWillReceiveProps(nextProps) {
         if (nextProps.foo !== this.state.foo) {
           this.setState(
             {
@@ -444,7 +446,7 @@ describe('setState', () => {
         }
       }
 
-      render() {
+      public render() {
         return <div>{this.state.foo}</div>;
       }
     }
@@ -457,19 +459,19 @@ describe('setState', () => {
   });
 
   it('Should have new state in render when changing state during componentWillMount and render only once', () => {
-    let changeFoo;
+    // const changeFoo; // TODO: What is this?
     const spy = sinon.spy();
 
     class Parent extends Component {
+      public state = {
+        foo: 'bar'
+      };
+
       constructor(props, context) {
         super(props, context);
-
-        this.state = {
-          foo: 'bar'
-        };
       }
 
-      render() {
+      public render() {
         return (
           <div>
             <Child foo={this.state.foo} />
@@ -479,16 +481,16 @@ describe('setState', () => {
     }
 
     let renderCount = 0;
-    class Child extends Component {
+    class Child extends Component<{foo: string}> {
+      public state = {
+        foo: this.props.foo
+      };
+
       constructor(props, context) {
         super(props, context);
-
-        this.state = {
-          foo: props.foo
-        };
       }
 
-      componentWillMount() {
+      public componentWillMount() {
         this.setState(
           {
             foo: '1'
@@ -524,7 +526,7 @@ describe('setState', () => {
         );
       }
 
-      render() {
+      public render() {
         renderCount++;
         return <div>{this.state.foo}</div>;
       }
@@ -543,31 +545,31 @@ describe('setState', () => {
     let doSomething;
 
     class Parent extends Component {
+      public state = {
+        active: false,
+        foo: 'b'
+      };
+
       constructor(props, context) {
         super(props, context);
-
-        this.state = {
-          active: false,
-          foo: 'b'
-        };
 
         this._setBar = this._setBar.bind(this);
         doSomething = this._setActive = this._setActive.bind(this);
       }
 
-      _setBar() {
+      private _setBar() {
         this.setState({
           foo: 'bar'
         });
       }
 
-      _setActive() {
+      private _setActive() {
         this.setState({
           active: true
         });
       }
 
-      render() {
+      public render() {
         return (
           <div>
             <div>{this.state.foo}</div>
@@ -577,18 +579,18 @@ describe('setState', () => {
       }
     }
 
-    class Child extends Component {
+    class Child extends Component<{foo: string, callback: () => void}> {
       constructor(props, context) {
         super(props, context);
       }
 
-      componentWillUpdate(nextProps) {
+      public componentWillUpdate(nextProps) {
         if (nextProps.foo !== 'bar') {
           this.props.callback();
         }
       }
 
-      render() {
+      public render() {
         return (
           <div>
             <div>{this.props.foo}</div>
@@ -611,31 +613,31 @@ describe('setState', () => {
     let doSomething;
 
     class Parent extends Component {
+      public state = {
+        active: false,
+        foo: 'b'
+      };
+
       constructor(props, context) {
         super(props, context);
-
-        this.state = {
-          active: false,
-          foo: 'b'
-        };
 
         this._setBar = this._setBar.bind(this);
         doSomething = this._setActive = this._setActive.bind(this);
       }
 
-      _setBar() {
+      private _setBar() {
         this.setState({
           foo: 'bar'
         });
       }
 
-      _setActive() {
+      private _setActive() {
         this.setState({
           active: true
         });
       }
 
-      render() {
+      public render() {
         return (
           <div>
             <div>{this.state.foo}</div>
@@ -647,12 +649,12 @@ describe('setState', () => {
       }
     }
 
-    class Child extends Component {
+    class Child extends Component<{foo: string, callback: () => void}> {
       constructor(props, context) {
         super(props, context);
       }
 
-      componentWillReceiveProps(nextProps) {
+      public componentWillReceiveProps(nextProps) {
         if (nextProps.foo !== 'bar') {
           this.setState({
             foo: 'bbaarr'
@@ -662,7 +664,7 @@ describe('setState', () => {
         }
       }
 
-      render() {
+      public render() {
         return (
           <div>
             <div>{this.props.foo}</div>
@@ -683,23 +685,23 @@ describe('setState', () => {
     let doSomething;
 
     class Parent extends Component {
+      public state = {
+        foo: 'b'
+      };
+
       constructor(props, context) {
         super(props, context);
-
-        this.state = {
-          foo: 'b'
-        };
 
         doSomething = this._setBar = this._setBar.bind(this);
       }
 
-      _setBar(p) {
+      private _setBar(p) {
         this.setState({
           foo: p
         });
       }
 
-      render() {
+      public render() {
         return <div>{this.state.foo}</div>;
       }
     }
@@ -720,12 +722,12 @@ describe('setState', () => {
   it('Set state callback should have context of caller component (forced) - as per React', () => {
     let cnt = 0;
 
-    class Com extends Component {
-      doTest() {
+    class Com extends Component<any, any> {
+      public doTest() {
         expect(this.state.a).toBe(cnt);
       }
 
-      componentWillMount() {
+      public componentWillMount() {
         this.setState(
           {
             a: ++cnt
@@ -734,7 +736,7 @@ describe('setState', () => {
         );
       }
 
-      componentDidMount() {
+      public componentDidMount() {
         this.setState(
           {
             a: ++cnt
@@ -743,7 +745,7 @@ describe('setState', () => {
         );
       }
 
-      render() {
+      public render() {
         return <div>1</div>;
       }
     }
@@ -761,7 +763,7 @@ describe('setState', () => {
         this.state = FooBarState;
       }
 
-      render(props, state) {
+      public render(props, state) {
         expect(state).toBe(FooBarState);
         expect(this.state).toBe(FooBarState);
         expect(state === FooBarState).toBe(true);
@@ -784,23 +786,23 @@ describe('setState', () => {
       return <div>{(context.active ? 'ACTIVE' : 'INACTIVE') + '   :   ' + (context.state.active ? 'ACTIVE' : 'INACTIVE')}</div>;
     }
 
-    class Container extends Component {
+    class Container extends Component<{active: boolean}> {
+      public state = {
+        active: false
+      };
+
       constructor(props, context) {
         super(props, context);
-
-        this.state = {
-          active: false
-        };
       }
 
-      getChildContext() {
+      public getChildContext() {
         return {
           active: this.state.active,
           state: this.state
         };
       }
 
-      componentWillReceiveProps(nextProps) {
+      public componentWillReceiveProps(nextProps) {
         if (this.state.active !== nextProps.active) {
           this.setState({
             active: nextProps.active
@@ -808,30 +810,30 @@ describe('setState', () => {
         }
       }
 
-      render() {
+      public render() {
         return <Child />;
       }
     }
 
     let updater;
     class App extends Component {
+      public state = {
+        active: false
+      };
+
       constructor(props, context) {
         super(props, context);
-
-        this.state = {
-          active: false
-        };
 
         updater = this.didClick.bind(this);
       }
 
-      didClick(e) {
+      public didClick(e) {
         this.setState({
           active: !this.state.active
         });
       }
 
-      render() {
+      public render() {
         return (
           <div>
             <Container active={this.state.active} />

--- a/packages/inferno/__tests__/singlepatches.spec.tsx
+++ b/packages/inferno/__tests__/singlepatches.spec.tsx
@@ -1,8 +1,8 @@
-import { Component, render } from 'inferno';
+import {Component, render, SFC} from 'inferno';
 import sinon, { assert } from 'sinon';
 
 describe('All single patch variations', () => {
-  let templateRefSpy = sinon.spy();
+  const templateRefSpy = sinon.spy();
   let container;
   let mountSpy;
   let updateSpy;
@@ -32,32 +32,35 @@ describe('All single patch variations', () => {
     expect(container.innerHTML).toBe('');
   }
 
+  /* tslint:disable:no-empty */
   class ComA extends Component {
-    componentDidMount() {}
+    public componentDidMount() {}
 
-    componentWillMount() {}
+    public componentWillMount() {}
 
-    componentWillReceiveProps(nextProps, nextContext) {}
+    public componentWillReceiveProps(nextProps, nextContext) {}
 
-    shouldComponentUpdate(nextProps, nextState, nextContext) {
+    public shouldComponentUpdate(nextProps, nextState, nextContext) {
       return true;
     }
 
-    componentWillUpdate(nextProps, nextState, nextContext) {}
+    public componentWillUpdate(nextProps, nextState, nextContext) {}
 
-    componentDidUpdate(prevProps, prevState, prevContext) {}
+    public componentDidUpdate(prevProps, prevState, prevContext) {}
 
-    componentWillUnmount() {}
+    public componentWillUnmount() {}
 
-    render({ children }) {
+    public render({ children }) {
       return children;
     }
   }
+  /* tslint:enable */
 
   mountSpy = sinon.spy(ComA.prototype, 'componentWillMount');
   updateSpy = sinon.spy(ComA.prototype, 'componentWillUpdate');
   unmountSpy = sinon.spy(ComA.prototype, 'componentWillUnmount');
 
+  // @ts-ignore
   function ComB({ children }) {
     return children;
   }
@@ -218,9 +221,10 @@ describe('All single patch variations', () => {
 
     it('vNode (Com different)', () => {
       class ComC extends Component {
+        // tslint:disable-next-line
         componentWillMount() {}
 
-        render({ children }) {
+        public render({ children }) {
           return children;
         }
       }
@@ -285,9 +289,9 @@ describe('All single patch variations', () => {
     it('Should never update if defaultProps refs SCU returns false', () => {
       let counter = 0;
 
-      function Static() {
+      const Static: SFC = function() {
         return <div>{counter}</div>;
-      }
+      };
 
       Static.defaultHooks = {
         onComponentShouldUpdate() {
@@ -319,9 +323,9 @@ describe('All single patch variations', () => {
       let counter = 0;
       let mountCounter = 0;
 
-      function Static() {
+      const Static: SFC = function() {
         return <div>{counter}</div>;
-      }
+      };
 
       Static.defaultHooks = {
         onComponentShouldUpdate() {
@@ -359,9 +363,9 @@ describe('All single patch variations', () => {
       let counter = 0;
       let mountCounter = 0;
 
-      function Static() {
+      const Static: SFC = function() {
         return <div>{counter}</div>;
-      }
+      };
 
       Static.defaultHooks = {
         onComponentShouldUpdate() {

--- a/packages/inferno/__tests__/state.spec.tsx
+++ b/packages/inferno/__tests__/state.spec.tsx
@@ -4,22 +4,22 @@ import { VNodeFlags } from 'inferno-vnode-flags';
 let renderCount = 0;
 
 class TestCWRP extends Component {
+  public state = {
+    a: 0,
+    b: 0
+  };
+
   constructor(props) {
     super(props);
-
-    this.state = {
-      a: 0,
-      b: 0
-    };
   }
 
-  componentWillReceiveProps() {
+  public componentWillReceiveProps() {
     this.setState({ a: 1 });
 
     expect(this.state.a).toBe(0); // It should be 0 because state is not synchronously updated
   }
 
-  render() {
+  public render() {
     if (renderCount === 0) {
       expect(this.state.a).toBe(0);
     } else if (renderCount === 1) {
@@ -79,44 +79,45 @@ describe('state', () => {
 
   describe('didUpdate and setState', () => {
     it('order', done => {
-      class Test extends Component {
+      class Test extends Component<{scrollTop: number}> {
+        public state = {
+          testScrollTop: 0
+        };
+
         constructor(props, context) {
           super(props, context);
-
-          this.state = {
-            testScrollTop: 0
-          };
         }
 
-        componentWillReceiveProps(nextProps) {
+        public componentWillReceiveProps(nextProps) {
           if (nextProps.scrollTop !== 0) {
             this.setState({ testScrollTop: nextProps.scrollTop });
           }
         }
 
-        componentDidUpdate(prevProps, prevState) {
+        public componentDidUpdate(prevProps, prevState) {
           expect(prevState.testScrollTop).toBe(0);
           expect(this.state.testScrollTop).toBe(200);
         }
 
-        render() {
+        public render() {
           return <div>aa</div>;
         }
       }
 
-      class Example extends Component {
+      class Example extends Component<{name: string}> {
+        public state = {
+          exampleScrollTop: 0
+        };
+
         constructor(props, context) {
           super(props, context);
-          this.state = {
-            exampleScrollTop: 0
-          };
         }
 
-        render() {
+        public render() {
           return <Test scrollTop={this.state.exampleScrollTop} />;
         }
 
-        componentDidMount() {
+        public componentDidMount() {
           setTimeout(() => {
             this.setState({ exampleScrollTop: 200 });
 
@@ -127,7 +128,7 @@ describe('state', () => {
         }
       }
 
-      render(<Example name="World" />, container);
+      render(<Example name="World"/>, container);
     });
   });
 });

--- a/packages/inferno/src/DOM/utils/componentutil.ts
+++ b/packages/inferno/src/DOM/utils/componentutil.ts
@@ -3,7 +3,7 @@ import { combineFrom, isArray, isFunction, isInvalid, isNull, isNullOrUndef, isS
 import { EMPTY_OBJ } from './common';
 import { VNodeFlags } from 'inferno-vnode-flags';
 
-export function createClassComponentInstance(vNode: VNode, Component, props: Props, context: Object) {
+export function createClassComponentInstance<P>(vNode: VNode, Component, props: Props<P>, context: Object) {
   const instance = new Component(props, context);
   vNode.children = instance;
   instance.$V = vNode;

--- a/packages/inferno/src/JSX.ts
+++ b/packages/inferno/src/JSX.ts
@@ -16,7 +16,9 @@ import {
   AnimationEventHandler,
   TransitionEventHandler,
   ChangeEventHandler,
-  Ref
+  Ref,
+  Refs,
+  Props
 } from 'inferno';
 
 export type NativeAnimationEvent = AnimationEvent;
@@ -60,10 +62,15 @@ declare global {
 
     interface Attributes {
       key?: any;
+
+      $HasVNodeChildren?: boolean;
+      $HasNonKeyedChildren?: boolean;
+      $HasKeyedChildren?: boolean;
+      $ChildFlag?: number;
     }
 
     interface ClassAttributes<T> extends Attributes {
-      ref?: Ref<T>;
+      ref?: Ref<T> | Refs<T>;
     }
 
     // string fallback for custom web-components
@@ -3205,7 +3212,7 @@ declare global {
     }
 
     // tslint:disable-next-line:no-empty-interface
-    interface IntrinsicAttributes extends _InfernoJSX.Attributes {}
+    interface IntrinsicAttributes<P> extends _InfernoJSX.Attributes, Props<P> {}
 
     // tslint:disable-next-line:no-empty-interface
     interface IntrinsicClassAttributes<T> extends _InfernoJSX.ClassAttributes<T> {}

--- a/packages/inferno/src/core/component.ts
+++ b/packages/inferno/src/core/component.ts
@@ -1,5 +1,5 @@
 import { VNodeFlags } from 'inferno-vnode-flags';
-import { Props, VNode, InfernoChildren } from './implementation';
+import { Props, VNode, InfernoChildren, Refs } from './implementation';
 import { combineFrom, isFunction, isNull, isNullOrUndef, throwError } from 'inferno-shared';
 import { updateClassComponent } from '../DOM/patching';
 import { callAll, EMPTY_OBJ, LIFECYCLE } from '../DOM/utils/common';
@@ -133,7 +133,7 @@ export class Component<P, S> {
   // Public
   public static defaultProps: {} | null = null;
   public state: S | null = null;
-  public props: P & Props;
+  public props: Props<P, this> & P;
   public context: any;
 
   // Internal properties
@@ -148,7 +148,7 @@ export class Component<P, S> {
   public $UPD: boolean = true; // UPDATING
   public $QU: Function[] | null = null; // QUEUE
 
-  constructor(props: P, context?: any) {
+  constructor(props?: P, context?: any) {
     /** @type {object} */
     this.props = props || (EMPTY_OBJ as P);
 
@@ -194,6 +194,7 @@ export interface StatelessComponent<P = {}> {
 
   defaultProps?: Partial<P>;
   displayName?: string;
+  defaultHooks?: Refs<P>;
 }
 
 export interface ComponentClass<P = {}> {

--- a/packages/inferno/src/core/implementation.ts
+++ b/packages/inferno/src/core/implementation.ts
@@ -26,17 +26,17 @@ export interface VNode<P = {}> {
   isValidated?: boolean;
   key: null | number | string;
   parentVNode: VNode | null;
-  props: Props & P | null;
+  props: Props<P> & P | null;
   ref: Ref | Refs<P> | null;
   type: any;
 }
 export type InfernoInput = VNode | null | string | number;
 export type Ref<T = Element> = { bivarianceHack(instance: T | null): any }['bivarianceHack'];
-export type InfernoChildren = string | number | boolean | undefined | VNode | Array<string | number | VNode> | null;
+export type InfernoChildren = string | number | boolean | undefined | VNode | Array<string | number | VNode | null | undefined> | null;
 
-export interface Props<T = Element> {
+export interface Props<P, T = Element> extends Refs<P> {
   children?: InfernoChildren;
-  ref?: Ref<T> | null;
+  ref?: Ref<T> | Refs<P> | null;
   key?: any;
   className?: string;
 }
@@ -87,7 +87,7 @@ export function createVNode<P>(
   className?: string | null,
   children?: InfernoChildren,
   childFlags?: ChildFlags,
-  props?: Props & P | null,
+  props?: Props<P> & P | null,
   key?: string | number | null,
   ref?: Ref | Refs<P> | null
 ): VNode {
@@ -116,7 +116,7 @@ export function createVNode<P>(
   return vNode;
 }
 
-export function createComponentVNode<P>(flags: VNodeFlags, type, props?: Props & P | null, key?: null | string | number, ref?: Ref | Refs<P> | null) {
+export function createComponentVNode<P>(flags: VNodeFlags, type, props?: Props<P> & P | null, key?: null | string | number, ref?: Ref | Refs<P> | null) {
   if (process.env.NODE_ENV !== 'production') {
     if (flags & VNodeFlags.HtmlElement) {
       throwError('Creating element vNodes using createComponentVNode is not allowed. Use Inferno.createVNode method.');


### PR DESCRIPTION
 **Objective**

This PR converts some tests to TypeScript to test the typings. It also fixes some issues with typings found when converting tests. Typings now have stronger types for refs and support for $ChildFlags and friends.
