### PR TITLE
enables BrowserRouter to have a jsx child

### DIFF
--- a/packages/inferno-router/src/BrowserRouter.ts
+++ b/packages/inferno-router/src/BrowserRouter.ts
@@ -9,7 +9,7 @@ export interface IBrowserRouterProps {
   forceRefresh?: boolean;
   getUserConfirmation?: () => {};
   keyLength?: number;
-  children: Array<Component<any, any>>;
+  children: Array<Component<any, any>> | JSX.Element;
 }
 
 export class BrowserRouter extends Component<IBrowserRouterProps, any> {


### PR DESCRIPTION
Fixes TS errors when having a JSX element as a child (such as i.e. <Switch/>)