### PR TITLE
Fix `Maximum callstack size exceeded` when using angularjs 

### DIFF
--- a/packages/inferno/src/DOM/events/delegation.ts
+++ b/packages/inferno/src/DOM/events/delegation.ts
@@ -70,7 +70,9 @@ function normalizeEventName(name) {
 
 function stopPropagation() {
   this.cancelBubble = true;
-  this.stopImmediatePropagation();
+  if (!this.immediatePropagationStopped) {
+    this.stopImmediatePropagation();
+  }
 }
 
 function attachEventToDocument(name: string) {


### PR DESCRIPTION
## PR Template

**Objective**

Prevent infinite recursion when using angular with inspire-tree-dom. 
See https://github.com/helion3/inspire-tree-dom/issues/17

**Closes Issue**

It closes Issue https://github.com/helion3/inspire-tree-dom/issues/17
