### PR TITLE
$EV of undefined

### DIFF
--- a/packages/inferno/src/DOM/patching.ts
+++ b/packages/inferno/src/DOM/patching.ts
@@ -58,7 +58,7 @@ export function patchElement(lastVNode: VNode, nextVNode: VNode, parentDom: Elem
   if (lastVNode.type !== nextTag) {
     replaceWithNewNode(lastVNode, nextVNode, parentDom, lifecycle, context, isSVG);
   } else {
-    const dom = lastVNode.dom as Element;
+    const dom = (lastVNode.dom || parentDom) as Element;
     const nextFlags = nextVNode.flags;
     const lastProps = lastVNode.props;
     const nextProps = nextVNode.props;


### PR DESCRIPTION
## PR Template

**Objective**

This PR uses parentDom if lastVNode.dom is undefined. This seems to work but might not be entirely correct. How I ran into this issue is fully described here: https://github.com/helion3/inspire-tree-dom/issues/18. I can create an issue in this repo as well if desired. I believe this issue arose in a recent version of inferno. I suspect this change in version caused it: https://github.com/helion3/inspire-tree-dom/commit/488a2d42bf5a50e54d440a06a08ff13a1453ac29#diff-b9cfc7f2cdf78a7f4b91a753d10865a2R11


**Closes Issue**

It closes Issue https://github.com/helion3/inspire-tree-dom/issues/18
