### PR TITLE
packages/router: HashRouter could have JSX child

### DIFF
--- a/packages/inferno-router/src/HashRouter.ts
+++ b/packages/inferno-router/src/HashRouter.ts
@@ -8,7 +8,7 @@ export interface IHashRouterProps {
   basename?: string;
   getUserConfirmation?: () => {};
   hashType?: string;
-  children: Array<Component<any, any>>;
+  children: Array<Component<any, any>> | JSX.Element;
 }
 
 export class HashRouter extends Component<IHashRouterProps, any> {


### PR DESCRIPTION
**Objective**

`HashRouter` should accept `JSX.Elements` as child, same as `BrowserRouter`.
