### PR TITLE
packages/router: fix TS ERROR when use <Route/>

### DIFF
--- a/packages/inferno/src/core/component.ts
+++ b/packages/inferno/src/core/component.ts
@@ -130,7 +130,7 @@ export interface ComponentLifecycle<P, S> {
 export interface Component<P = {}, S = {}> extends ComponentLifecycle<P, S> {}
 export class Component<P, S> {
   // Public
-  public static defaultProps: {} | null = null;
+  public static defaultProps?: Partial<any>;
   public state: S | null = null;
   public props: Props<P, this> & P;
   public context: any;


### PR DESCRIPTION
**Objective**

This PR fixes a TS ERROR when using `<Route component={Compo}>`.

```bash
[tsl] ERROR in index.tsx(xx,yy)
      TS2326: Types of property 'component' are incompatible.
  Type 'typeof Login' is not assignable to type 'ComponentClass<RouteComponentProps<any>> | StatelessComponent<RouteComponentProps<any>> | Compone...'.
    Type 'typeof Compo' is not assignable to type 'StatelessComponent<any>'.
      Types of property 'defaultProps' are incompatible.
        Type '{} | null' is not assignable to type 'Partial<any> | undefined'.
          Type 'null' is not assignable to type 'Partial<any> | undefined'.
```

Component defaultProps should have same type as ComponentType and ComponentClass.

It would just work if you change the file `index.d.ts` under `node_modules/inferno/dist` ...