### PR TITLE
removing word undefined in mobx logger when rootNodeID is not defined

### DIFF
--- a/packages/inferno-mobx/src/observer.ts
+++ b/packages/inferno-mobx/src/observer.ts
@@ -103,7 +103,7 @@ const reactiveMixin = {
 
     // Generate friendly name for debugging
     const initialName = this.displayName || this.name || (this.constructor && (this.constructor.displayName || this.constructor.name)) || '<component>';
-    const rootNodeID = this._reactInternalInstance && this._reactInternalInstance._rootNodeID;
+    const rootNodeID = (this._reactInternalInstance && this._reactInternalInstance._rootNodeID) || null;
 
     /**
      * If props are shallowly modified, react will render anyway,
@@ -151,7 +151,7 @@ const reactiveMixin = {
     let isRenderingPending = false;
 
     const initialRender = () => {
-      reaction = new Reaction(`${initialName}#${rootNodeID}.render()`, () => {
+      reaction = new Reaction(`${initialName}${!rootNodeID ? '' : `#${rootNodeID}`}.render()`, () => {
         if (!isRenderingPending) {
           // N.B. Getting here *before mounting* means that a component constructor has side effects (see the relevant test in misc.js)
           // This unidiomatic React usage but React will correctly warn about this so we continue as usual

--- a/packages/inferno-mobx/src/observer.ts
+++ b/packages/inferno-mobx/src/observer.ts
@@ -103,7 +103,6 @@ const reactiveMixin = {
 
     // Generate friendly name for debugging
     const initialName = this.displayName || this.name || (this.constructor && (this.constructor.displayName || this.constructor.name)) || '<component>';
-    const rootNodeID = (this._reactInternalInstance && this._reactInternalInstance._rootNodeID) || null;
 
     /**
      * If props are shallowly modified, react will render anyway,
@@ -151,7 +150,7 @@ const reactiveMixin = {
     let isRenderingPending = false;
 
     const initialRender = () => {
-      reaction = new Reaction(`${initialName}${!rootNodeID ? '' : `#${rootNodeID}`}.render()`, () => {
+      reaction = new Reaction(`${initialName}.render()`, () => {
         if (!isRenderingPending) {
           // N.B. Getting here *before mounting* means that a component constructor has side effects (see the relevant test in misc.js)
           // This unidiomatic React usage but React will correctly warn about this so we continue as usual


### PR DESCRIPTION
In MobX logger and MobX Chrome Dev Tools all Reaction names has `undefined` word because `rootNodeID` in most cases not found. 
This PR will check if `rootNodeID` is undefined then Reaction name does not contain word `undefined`

