### PR TITLE
Removed not necessary stopPropagation, it was needed for checkbox and…

### DIFF
--- a/packages/inferno/src/DOM/wrappers/wrapper.ts
+++ b/packages/inferno/src/DOM/wrappers/wrapper.ts
@@ -21,7 +21,6 @@ function triggerEventListener(props, methodName, e) {
 
 export function createWrappedFunction(methodName: string | string[], applyValue?: Function): Function {
   const fnMethod = function(e) {
-    e.stopPropagation();
     const vNode = this.$V;
     // If vNode is gone by the time event fires, no-op
     if (!vNode) {


### PR DESCRIPTION
Removed not necessary stopPropagation, it was needed for checkbox and moved in emptyWwrapper method.

 *Before* submitting a PR please:
stopPropagation was execute for events like "input", "change", "click"

