### PR TITLE
Add Simple JS Counter example

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,6 +162,7 @@ render(
 If you have built something using Inferno you can add them here:
 
 - [**Simple Clock** (@JSFiddle)](https://jsfiddle.net/pzmqLjo7/)
+- [**Simple JS Counter** (@github/scorsi)](https://github.com/scorsi/inferno-cerebral-fusebox) : SSR Inferno (view) + Cerebral (state manager) + FuseBox (build system/bundler)
 
 
 ## Getting Started

--- a/README.md
+++ b/README.md
@@ -162,7 +162,7 @@ render(
 If you have built something using Inferno you can add them here:
 
 - [**Simple Clock** (@JSFiddle)](https://jsfiddle.net/pzmqLjo7/)
-- [**Simple JS Counter** (@github/scorsi)](https://github.com/scorsi/inferno-cerebral-fusebox) : SSR Inferno (view) + Cerebral (state manager) + FuseBox (build system/bundler)
+- [**Simple JS Counter** (@github/scorsi)](https://github.com/scorsi/simple-counter-inferno-cerebral-fusebox) : SSR Inferno (view) + Cerebral (state manager) + FuseBox (build system/bundler)
 
 
 ## Getting Started


### PR DESCRIPTION
Add a Simple Counter example in the `README.md`.
This example use Inferno with SSR, Cerebral as State Manager and FuseBox as bundler/building system.