### PR TITLE
#1391 - add all valid line input types for use by oninput handler

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -76,7 +76,7 @@ And make sure the PR haven't been published before!
 
 There isn't (yet) a formal style guide for Inferno, so please take care to adhere to existing conventions:
 
-* Tabs, not spaces!
+* 2-space indentation, not tabs!
 * Semi-colons
 * Single-quotes for strings
 

--- a/packages/inferno-compat/src/index.ts
+++ b/packages/inferno-compat/src/index.ts
@@ -113,6 +113,21 @@ const Children = {
 
 const version = '15.4.2';
 
+const validLineInputs = {
+  date: true,
+  'datetime-local': true,
+  email: true,
+  month: true,
+  number: true,
+  password: true,
+  search: true,
+  tel: true,
+  text: true,
+  time: true,
+  url: true,
+  week: true
+};
+
 function normalizeGenericProps(props) {
   for (const prop in props) {
     if (prop === 'onDoubleClick') {
@@ -133,10 +148,10 @@ function normalizeGenericProps(props) {
 
 function normalizeFormProps<P>(name: string, props: Props<P> | any) {
   if ((name === 'input' || name === 'textarea') && props.type !== 'radio' && props.onChange) {
-    const type = props.type;
+    const type = props.type && props.type.toLowerCase();
     let eventName;
 
-    if (!type || type === 'text') {
+    if (!type || validLineInputs[type]) {
       eventName = 'oninput';
     }
 


### PR DESCRIPTION
**Objective**

Check onInput handler input type against an array of valid HTML5 line input types (ie. boxes you can type characters into), instead of just `type="text"`.

Also updated contribution guidelines to match current code style; and what is set in editorconfig + used by prettier.

**Closes Issue**

Closes #1391 