### PR TITLE
inferno-clone-vnode doesn't include children in cloned node

### DIFF
--- a/packages/inferno-clone-vnode/__tests__/cloneVNode.spec.jsx
+++ b/packages/inferno-clone-vnode/__tests__/cloneVNode.spec.jsx
@@ -480,4 +480,116 @@ describe('cloneVNode (JSX)', () => {
       expect(innerHTML(container.innerHTML)).toEqual(innerHTML('<div></div>'));
     });
   });
+
+  describe("without children specified", () => {
+    it("should render children one level deep", () => {
+      class NameContainer extends Component {
+        render() {
+          const children = this.props.children.map(c =>
+            cloneVNode(c, {
+              name: "Henry"
+            })
+          );
+
+          return <span>{children}</span>;
+        }
+      }
+
+      const NameViewer = () => {
+        return (
+          <NameContainer>
+            <div className="test">
+              <span>A child that should render after the clone</span>
+            </div>
+            <div>
+              <span>A child that should render after the clone</span>
+            </div>
+          </NameContainer>
+        );
+      };
+
+      render(<NameViewer />, container);
+
+      expect(container.innerHTML).toBe(`<span><div class="test" name="Henry"><span>A child that should render after \
+the clone</span></div><div name="Henry"><span>A child that should render after the clone</span></div></span>`);
+    });
+
+    it('should render children two levels deep', () => {
+      const items = [
+        { name: "Mike Brady" }, 
+        { name: "Carol Brady" }, 
+        { name: "Greg Brady" }, 
+        { name: "Marcia Brady" }
+      ];
+      const items2 = [
+        { age: 28 }, 
+        { age: 26 }, 
+        { age: 16 }, 
+        { age: 15 }
+      ];
+
+      class Wrapper1 extends Component {
+        render() {
+          const children = cloneVNode(this.props.children, { items });
+          return <div className="wrapper1">{children}</div>;
+        }
+      }
+  
+      class Wrapper2 extends Component {
+        render() {
+          const children = this.props.children.map(c => {
+            return cloneVNode(c, {
+              propsIndex: c.props && c.props.index,
+              name: (c.props && c.props.index) != null ? this.props.items[c.props.index].name : "default-name",
+              age: (c.props && c.props.index) != null ? this.props.items2[c.props.index].age : "default-age"
+            });
+          });
+  
+          return <div className="wrapper2">{children}</div>;
+        }
+      }
+  
+      class Item extends Component {
+        render() {
+          return (
+            <span>
+              item {this.props.name} - age: {this.props.age}
+            </span>
+          );
+        }
+      }
+  
+      class NormalItem extends Component {
+        render() {
+          return (
+            <span>
+              Normal Item {this.props.name} - age: {this.props.age}
+            </span>
+          );
+        }
+      }
+  
+      class App extends Component {
+        render() {
+          return (
+            <Wrapper1>
+              <Wrapper2 items2={items2}>
+                <NormalItem />
+                <NormalItem />
+                {items.map((d, idx) => <Item index={idx} />)}
+              </Wrapper2>
+            </Wrapper1>
+          );
+        }
+      }
+
+      // render an instance of Clock into <body>:
+      render(<App />, container);
+
+      expect(container.innerHTML).toBe(`<div class="wrapper1"><div class="wrapper2"><span>Normal Item default-name \
+- age: default-age</span><span>Normal Item default-name - age: default-age</span><span>item Mike Brady - age: \
+28</span><span>item Carol Brady - age: 26</span><span>item Greg Brady - age: 16</span><span>item Marcia Brady \
+- age: 15</span></div></div>`);
+    });
+  });
 });

--- a/packages/inferno-shared/__tests__/shared.spec.jsx
+++ b/packages/inferno-shared/__tests__/shared.spec.jsx
@@ -1,0 +1,14 @@
+import { flatten } from 'inferno-shared';
+
+describe('Shared functions', () => {
+  describe('flatten', () => {
+    let xs;
+    beforeEach(() => {
+      xs = ['h', 'o', ['w', [' '], ['n', 'o', ['w'], ' '], 'b'], 'r', ['o', [['w', ['n'], ' '], 'c', [[[[[['o', [['w']]]]]]]]]]];
+    });
+
+    it('should flatten an array to a single level', () => {
+      expect(flatten(xs)).toEqual(['h', 'o', 'w', ' ', 'n', 'o', 'w', ' ', 'b', 'r', 'o', 'w', 'n', ' ', 'c', 'o', 'w']);
+    });
+  });
+});

--- a/packages/inferno-shared/src/index.ts
+++ b/packages/inferno-shared/src/index.ts
@@ -70,3 +70,8 @@ export function combineFrom(first: {} | null, second: {} | null): object {
   }
   return out;
 }
+
+export const flatten = (xs: {} | any[]): any[] => {
+  const items = Array.isArray(xs) ? xs : [xs];
+  return items.reduce((a, b) => a.concat(Array.isArray(b) ? flatten(b) : b), []);
+};


### PR DESCRIPTION
Fixes #1393.

inferno-clone-vnode does not currently clone existing children of a
vnode. Instead, we are required to specify the children to include.
While this works, it seems redundant and does not behave in the same
way as React.

This patch will allow the children of a node to automatically be cloned if no children
props are specified in the second parameter and no children are
specified in the third parameter. Furthermore, this patch will flatten
the list of children. This will allow all children to be accounted for.
For example:

```
const itemList = [{name: 'a'}, {name: 'b'}];
<Wrapper>
    <StaticItem1 />
    <StaticItem2 />
    {itemList.map(x => <StaticItem name={x.name} />)}
</Wrapper>
```

Signed-off-by: Will Johnson <wjohnson@whamcloud.com>
