### PR TITLE
CreateElement: Fix multiple children argument type

### DIFF
--- a/packages/inferno-create-element/__tests__/createElementTyped.spec.tsx
+++ b/packages/inferno-create-element/__tests__/createElementTyped.spec.tsx
@@ -1,0 +1,66 @@
+import { render } from 'inferno';
+import { createElement } from 'inferno-create-element';
+
+describe('CreateElement (non-JSX)', () => {
+    let container;
+
+    beforeEach(function () {
+        container = document.createElement('div');
+        document.body.appendChild(container);
+    });
+
+    afterEach(function () {
+        render(null, container);
+        container.innerHTML = '';
+        document.body.removeChild(container);
+    });
+
+    it('Should render zero children', () => {
+        const App = () => createElement('div', null);
+        render(App(), container);
+    });
+
+    it('Should render null children', () => {
+        const App = () => createElement('div', null, null);
+        render(App(), container);
+    });
+
+    it('Should render undefined children', () => {
+        const App = () => createElement('div', null, undefined);
+        render(App(), container);
+    });
+
+    it('Should render one child', () => {
+        const App = () => createElement(
+            'div',
+            null,
+            createElement('div', { className: 'title' }, 'Example')
+        );
+
+        render(App(), container);
+    });
+
+    it('Should render multiple children', () => {
+        const App = () => createElement(
+            'div',
+            null,
+            createElement('div', { className: 'title' }, 'Example'),
+            createElement('button', { type: 'button', }, 'Do a thing')
+        );
+
+        render(App(), container);
+    });
+
+    it('Should render array of children', () => {
+        const App = () => createElement(
+            'div',
+            null,
+            [
+                createElement('div', { className: 'title' }, 'Example'),
+                createElement('button', { type: 'button', }, 'Do a thing')
+            ]
+        );
+
+        render(App(), container);
+    });
+});

--- a/packages/inferno-create-element/src/index.ts
+++ b/packages/inferno-create-element/src/index.ts
@@ -16,8 +16,9 @@ const componentHooks = {
  * @param {string|Function|Component<any, any>} type Type of node
  * @param {object=} props Optional props for virtual node
  * @param {...{object}=} _children Optional children for virtual node
- * @returns {VNode} new virtual ndoe
+ * @returns {VNode} new virtual node
  */
+export function createElement<T>(type: string | Function | Component<any, any>, props?: T & Props<T> | null, ..._children: any[]): VNode;
 export function createElement<T>(type: string | Function | Component<any, any>, props?: T & Props<T> | null, _children?: any): VNode {
   if (process.env.NODE_ENV !== 'production') {
     if (isInvalid(type)) {


### PR DESCRIPTION
 *Before* submitting a PR please:
 - Include tests for the functionality you are adding! See CONTRIBUTING.md for details how to run tests.
 - Make sure you have based your branch off the [dev branch](https://github.com/infernojs/inferno/tree/dev).
 - Submit your PR against the [dev branch](https://github.com/infernojs/inferno/tree/dev).
 - Run `npm run build` and check that the build succeeds.
 - Ensure that the PR hasn't been submitted before.

---

## PR Template

**Objective**

This PR unbreaks type check of creating elements with multiple children after upgrade to Inferno 6:

```js
createElement(
  Switch,
  undefined,
  createElement(Route, { component: HomeScreen, exact: true, path: "/" }),
  createElement(Route, { component: InputScreen, path: "/:name/:value" })
)
```

**Closes Issue**

It closes no open issue.