### PR TITLE
Component: Be assignable as IComponentConstructor

### DIFF
--- a/packages/inferno/__tests__/component.class.spec.tsx
+++ b/packages/inferno/__tests__/component.class.spec.tsx
@@ -1,0 +1,45 @@
+import { Component, IComponentConstructor } from 'inferno';
+
+describe('Component', () => {
+  it('Should be assignable where IComponentConstructor is expected', () => {
+    class ClassName extends Component<{ className: string }, any> {
+      public render() {
+        return <div>{this.props.className}</div>
+      }
+    }
+    const $ClassName: IComponentConstructor<{ className: string }> = ClassName;
+    expect(ClassName).toBe($ClassName);
+
+    class None extends Component<{}, any> {
+      public render() {
+        return <div />
+      }
+    }
+    const $None: IComponentConstructor<{}> = None;
+    expect(None).toBe($None);
+
+    class Id extends Component<{ id: string }, any> {
+      public render() {
+        return <div>{this.props.id}</div>
+      }
+    }
+    const $Id: IComponentConstructor<{ id: string }> = Id;
+    expect(Id).toBe($Id);
+
+    class Two extends Component<{ className: string, id: string }, any> {
+      public render() {
+        return <div>{this.props.className} {this.props.id}</div>
+      }
+    }
+    const $Two: IComponentConstructor<{ className: string, id: string }> = Two;
+    expect(Two).toBe($Two);
+
+    class Whatever extends Component<any, any> {
+      public render() {
+        return <div />
+      }
+    }
+    const $Whatever: IComponentConstructor<any> = Whatever;
+    expect(Whatever).toBe($Whatever);
+  });
+});

--- a/packages/inferno/src/core/component.ts
+++ b/packages/inferno/src/core/component.ts
@@ -1,4 +1,4 @@
-import { IComponent, InfernoNode, Props, StatelessComponent } from './types';
+import { IComponent, InfernoNode, StatelessComponent } from './types';
 import { combineFrom, isFunction, isNullOrUndef, throwError } from 'inferno-shared';
 import { updateClassComponent } from '../DOM/patching';
 import { callAll, EMPTY_OBJ, findDOMfromVNode, renderCheck } from "../DOM/utils/common";
@@ -183,11 +183,11 @@ export class Component<P = {}, S = {}> implements IComponent<P, S> {
 
   public getChildContext?(): void;
 
-  public getSnapshotBeforeUpdate?(prevProps: Props<any>, prevState: S): any;
+  public getSnapshotBeforeUpdate?(prevProps: P, prevState: S): any;
 
   public static defaultProps?: any;
 
-  public static getDerivedStateFromProps?(nextProps: Props<any>, state: any): any;
+  public static getDerivedStateFromProps?(nextProps: any, state: any): any;
 
   public render(_nextProps: P, _nextState: S, _nextContext: any): InfernoNode | undefined {
     return null;


### PR DESCRIPTION
## PR Template

**Objective**

This PR fixes assignment of a component class that has no explicit props common with `Props<any>`, to a parameter that expects a constructor accepting the same props interface.

```js
/** @extends {Component<{ id: string }>} */
class Section extends Component {
  // ...
}

const View: IComponentConstructor<{ id: string }> = Section;
```

```
...
    Type 'Section' is not assignable to type 'IComponent<{ id: string; }, any>'.
      Types of property 'getSnapshotBeforeUpdate' are incompatible.
        Type '((prevProps: Props<any, Element>, prevState: any) => any) | undefined' is not assignable to type '((prevProps: { id: string; }, prevState: any) => any) | undefined'.
          Type '(prevProps: Props<any, Element>, prevState: any) => any' is not assignable to type '(prevProps: { id: string; }, prevState: any) => any'.
            Types of parameters 'prevProps' and 'prevProps' are incompatible.
              Type '{ id: string; }' has no properties in common with type 'Props<any, Element>'.
```

After changing `getSnapshotBeforeUpdate` signature to expect `P` type parameter, like all other methods on `Component`, rather than `Props<any>`, I'm no longer getting the error.

**Closes Issue**

It closes no existing issue.