### PR TITLE
Fix Switch component not matching/rendering nested array children correctly

### DIFF
--- a/packages/inferno-router/__tests__/Switch.spec.jsx
+++ b/packages/inferno-router/__tests__/Switch.spec.jsx
@@ -305,6 +305,50 @@ describe('Switch (jsx)', () => {
       );
     }).toThrowError(/You should not use <Switch> outside a <Router>/);
   });
+
+  it('matches and renders array children correctly', () => {
+    const node = document.createElement('div');
+
+    render(
+      <MemoryRouter initialEntries={['/bubblegum']}>
+        <Switch>
+          <Route path="/ice-cream" render={() => <div>beb</div>} />
+          {[<Route path="/bubblegum" render={() => <div>bub</div>} />]}
+          <Route path="/cupcakes" render={() => <div>cup</div>} />
+        </Switch>
+      </MemoryRouter>,
+      node
+    );
+
+    expect(node.innerHTML).not.toContain('beb');
+    expect(node.innerHTML).toContain('bub');
+    expect(node.innerHTML).not.toContain('cup');
+  });
+
+  it('matches and renders children in nested arrays correctly', () => {
+    const node = document.createElement('div');
+
+    render(
+      <MemoryRouter initialEntries={['/bubblegum']}>
+        <Switch>
+          {[[<Route path="/ice-cream" render={() => <div>beb</div>} />]]}
+          {[
+            <Route path="/something" render={() => <div>bab</div>} />,
+            <Route path="/something-else" render={() => <div>bib</div>} />,
+            [<Route path="/bubblegum" render={() => <div>bub</div>} />]
+          ]}
+          <Route path="/cupcakes" render={() => <div>cup</div>} />
+        </Switch>
+      </MemoryRouter>,
+      node
+    );
+
+    expect(node.innerHTML).toContain('bub');
+    expect(node.innerHTML).not.toContain('beb');
+    expect(node.innerHTML).not.toContain('bab');
+    expect(node.innerHTML).not.toContain('bib');
+    expect(node.innerHTML).not.toContain('cup');
+  });
 });
 
 describe('A <Switch location>', () => {


### PR DESCRIPTION
**Objective**

This PR introduces a change to the way a Switch handles its child components, allowing for (nested) array children to sit next to regular component children.

A rough example of this would be the following:

```jsx
<Switch>
  { topics.map(topic =>
    <Route exact path={`/${topic.alias}`}><SomeComponent topic={topic} /></Route>) }
  <Route component={NotFound} />
</Switch>
```

Before this fix, this construct would result in a `TypeError: Cannot read property 'path' of undefined`.

See the added tests in `Switch.spec.jsx` for more examples.

When moving the child handling into a separate function, I have left the naming intact from the existing implementation, as this is my first attempt at contributing to this awesome project and I didn't want to rummage around too much. I'm always happy about feedback!