### PR TITLE
Fix snapshots while using compat mode (props.children - #1451)

### DIFF
--- a/packages/inferno-compat/__tests__/ReactChildren.spec.jsx
+++ b/packages/inferno-compat/__tests__/ReactChildren.spec.jsx
@@ -7,7 +7,7 @@
  * @emails react-core
  */
 
-import React from 'inferno-compat';
+import React, { createVNode } from 'inferno-compat';
 
 describe('ReactChildren', function() {
   var ReactChildren;

--- a/packages/inferno-compat/__tests__/ReactES6Class.spec.jsx
+++ b/packages/inferno-compat/__tests__/ReactES6Class.spec.jsx
@@ -7,7 +7,7 @@
  * @emails react-core
  */
 
-import React from 'inferno-compat';
+import React, { createVNode, createComponentVNode } from 'inferno-compat';
 
 var ReactDOM = React;
 

--- a/packages/inferno-compat/__tests__/ReactJSXElement.spec.jsx
+++ b/packages/inferno-compat/__tests__/ReactJSXElement.spec.jsx
@@ -7,7 +7,7 @@
  * @emails react-core
  */
 
-import React from 'inferno-compat';
+import React, { createVNode, createComponentVNode } from 'inferno-compat';
 import { triggerEvent } from 'inferno-utils';
 import sinon from 'sinon';
 

--- a/packages/inferno-compat/__tests__/compat_children.spec.jsx
+++ b/packages/inferno-compat/__tests__/compat_children.spec.jsx
@@ -1,5 +1,5 @@
 import { innerHTML } from 'inferno-utils';
-import { createElement, isValidElement, render, Component } from 'inferno-compat';
+import { createElement, isValidElement, render, Component, createVNode, createComponentVNode } from 'inferno-compat';
 
 describe('Compat Children', () => {
   let container;

--- a/packages/inferno-compat/__tests__/misc.spec.jsx
+++ b/packages/inferno-compat/__tests__/misc.spec.jsx
@@ -10,7 +10,8 @@ import React, {
   hydrate,
   isValidElement,
   PropTypes,
-  unstable_renderSubtreeIntoContainer
+  unstable_renderSubtreeIntoContainer,
+  createVNode
 } from 'inferno-compat';
 
 describe('MISC', () => {

--- a/packages/inferno-compat/__tests__/styles.spec.jsx
+++ b/packages/inferno-compat/__tests__/styles.spec.jsx
@@ -1,4 +1,4 @@
-import { render, options } from 'inferno-compat';
+import { render, options, createVNode } from 'inferno-compat';
 import { innerHTML } from 'inferno-utils';
 
 describe('Compat - styles', () => {

--- a/packages/inferno-compat/__tests__/warnings.spec.jsx
+++ b/packages/inferno-compat/__tests__/warnings.spec.jsx
@@ -1,4 +1,4 @@
-import { render } from 'inferno-compat';
+import { render, createVNode } from 'inferno-compat';
 
 describe('Warnings', () => {
   let container;

--- a/packages/inferno-create-element/src/index.ts
+++ b/packages/inferno-create-element/src/index.ts
@@ -69,6 +69,8 @@ export function createElement<T>(type: string | IComponentConstructor<T> | State
           children = props.children; // always favour children args over props
         } else if (prop === 'ref') {
           ref = props.ref;
+        } else if (prop === (VNodeFlags.CompatElement+'')) {
+          flags |= VNodeFlags.CompatElement;
         } else {
           if (prop === 'contenteditable') {
             flags |= VNodeFlags.ContentEditable;
@@ -94,6 +96,8 @@ export function createElement<T>(type: string | IComponentConstructor<T> | State
           key = props.key;
         } else if (prop === 'ref') {
           ref = props.ref;
+        } else if (prop === (VNodeFlags.CompatElement+'')) {
+          flags |= VNodeFlags.CompatElement;
         } else if ((componentHooks as any)[prop] === 1) {
           if (!ref) {
             ref = {};

--- a/packages/inferno-test-utils/src/jest.ts
+++ b/packages/inferno-test-utils/src/jest.ts
@@ -1,6 +1,6 @@
-import { render, VNode, rerender } from 'inferno';
+import { render, VNode, rerender, options } from 'inferno';
 import { ChildFlags, VNodeFlags } from 'inferno-vnode-flags';
-import { isArray, isNullOrUndef } from 'inferno-shared';
+import { isArray, isNullOrUndef, isFunction } from 'inferno-shared';
 import { getTagNameOfVNode } from './utils';
 
 // Jest Snapshot Utilities
@@ -10,7 +10,13 @@ import { getTagNameOfVNode } from './utils';
 
 const symbolValue = typeof Symbol === 'undefined' ? 'react.test.json' : Symbol.for('react.test.json');
 
-function createSnapshotObject(object: object) {
+function createSnapshotObject(object: {children:any, props: any, type: string | undefined}) {
+  const optsSnapshotObject = options.createSnapshotObject;
+
+  if (isFunction(optsSnapshotObject)) {
+    optsSnapshotObject(object);
+  }
+
   Object.defineProperty(object, '$$typeof', {
     value: symbolValue
   });

--- a/packages/inferno-test-utils/src/jest.ts
+++ b/packages/inferno-test-utils/src/jest.ts
@@ -10,11 +10,11 @@ import { getTagNameOfVNode } from './utils';
 
 const symbolValue = typeof Symbol === 'undefined' ? 'react.test.json' : Symbol.for('react.test.json');
 
-function createSnapshotObject(object: {children:any, props: any, type: string | undefined}) {
+function createSnapshotObject(object: {children:any, props: any, type: string | undefined}, vNode: VNode) {
   const optsSnapshotObject = options.createSnapshotObject;
 
   if (isFunction(optsSnapshotObject)) {
-    optsSnapshotObject(object);
+    optsSnapshotObject(object, vNode);
   }
 
   Object.defineProperty(object, '$$typeof', {
@@ -77,7 +77,7 @@ function buildVNodeSnapshot(vNode: VNode) {
       children: childVNode,
       props: snapShotProps,
       type: getTagNameOfVNode(vNode)
-    });
+    }, vNode);
   } else if (flags & VNodeFlags.Text) {
     childVNode = vNode.children + '';
   }

--- a/packages/inferno-vnode-flags/src/index.ts
+++ b/packages/inferno-vnode-flags/src/index.ts
@@ -20,6 +20,7 @@ export const enum VNodeFlags {
   InUse = 1 << 14,
   ForwardRef = 1 << 15,
   Normalized = 1 << 16,
+  CompatElement = 1 << 17,
 
   /* Masks */
   ForwardRefComponent = ForwardRef | ComponentFunction,

--- a/packages/inferno/src/DOM/utils/common.ts
+++ b/packages/inferno/src/DOM/utils/common.ts
@@ -142,7 +142,7 @@ export const renderCheck = {
 
 export const options: {
   componentComparator: ((lastVNode: VNode, nextVNode: VNode) => boolean) | null;
-  createSnapshotObject: ((object: {children:any, props: any, type: string | undefined}) => void) | null;
+  createSnapshotObject: ((object: {children:any, props: any, type: string | undefined}, vNode: VNode) => void) | null;
   createVNode: ((vNode: VNode) => void) | null;
   renderComplete: ((rootInput: VNode | InfernoNode, parentDOM: Element | SVGAElement | ShadowRoot | DocumentFragment | HTMLElement | Node) => void) | null;
   reactStyles?: boolean;

--- a/packages/inferno/src/DOM/utils/common.ts
+++ b/packages/inferno/src/DOM/utils/common.ts
@@ -142,11 +142,13 @@ export const renderCheck = {
 
 export const options: {
   componentComparator: ((lastVNode: VNode, nextVNode: VNode) => boolean) | null;
+  createSnapshotObject: ((object: {children:any, props: any, type: string | undefined}) => void) | null;
   createVNode: ((vNode: VNode) => void) | null;
   renderComplete: ((rootInput: VNode | InfernoNode, parentDOM: Element | SVGAElement | ShadowRoot | DocumentFragment | HTMLElement | Node) => void) | null;
   reactStyles?: boolean;
 } = {
   componentComparator: null,
+  createSnapshotObject: null,
   createVNode: null,
   renderComplete: null
 };

--- a/packages/inferno/src/core/implementation.ts
+++ b/packages/inferno/src/core/implementation.ts
@@ -70,6 +70,8 @@ export function createComponentVNode<P>(
     }
   }
 
+  const compatFlag = flags & VNodeFlags.CompatElement;
+
   if ((flags & VNodeFlags.ComponentUnknown) !== 0) {
     if ((type as any).prototype && (type as any).prototype.render) {
       flags = VNodeFlags.ComponentClass;
@@ -80,6 +82,8 @@ export function createComponentVNode<P>(
       flags = VNodeFlags.ComponentFunction;
     }
   }
+
+  flags |= compatFlag;
 
   // set default props
   const defaultProps = (type as any).defaultProps;


### PR DESCRIPTION
Defines a VNodeFlag to mark VNodes created by inferno-compat.
Inject the Flag by wrapping necesary functions in inferno-compat and preserve the flag until its within the VNode.
Assumes that each react lib will be importing react, which will be replaced with inferno-compat.

How it works:
- abusing props to inject flag in createElement
- directly add the flag in other methods (createComponentVNode, createFragment, createVNode)
- preserve flag in createComponentVNode (inferno)
- import compat function to test to prevent babel-plugin-inferno to inject the original function without the flag.

Pros:
- fix the issue
-  if compat is activated, the performance of inferno nodes doesn't decreased, because the function options.createVNode will be called but does nothing.
- also snapshot VNodes will be cleaned up only for VNodes created by compat