### PR TITLE
allow suppress warnings for polyfilled components using legacy life c…

### DIFF
--- a/packages/inferno/src/DOM/utils/componentutil.ts
+++ b/packages/inferno/src/DOM/utils/componentutil.ts
@@ -7,15 +7,19 @@ import { VNode } from './../../core/types';
 function warnAboutOldLifecycles(component) {
   const oldLifecycles: string[] = [];
 
-  if (component.componentWillMount) {
+   // Don't warn about react polyfilled components.
+  if (component.componentWillMount
+      && component.componentWillMount.__suppressDeprecationWarning !== true) {
     oldLifecycles.push('componentWillMount');
   }
 
-  if (component.componentWillReceiveProps) {
+  if (component.componentWillReceiveProps
+      && component.componentWillReceiveProps.__suppressDeprecationWarning !== true) {
     oldLifecycles.push('componentWillReceiveProps');
   }
 
-  if (component.componentWillUpdate) {
+  if (component.componentWillUpdate
+      && component.componentWillUpdate.__suppressDeprecationWarning !== true) {
     oldLifecycles.push('componentWillUpdate');
   }
 


### PR DESCRIPTION
**Objective**

This PR does not show warnings when using mix legacy life cycle API's (old and new) and they are suppressed by polyfilled components.

**Closes Issue**

It closes Issue #1458.