### PR TITLE
Do not render property 'selectedIndex' as attribute of element 'select' when this option passed

### DIFF
--- a/packages/inferno/__tests__/select.spec.jsx
+++ b/packages/inferno/__tests__/select.spec.jsx
@@ -90,4 +90,20 @@ describe('Select selectedIndex', () => {
     expect(select.selectedIndex).toBe(3);
     expect(select.value).toBe('3');
   });
+
+  it('Should not render attribute selectedIndex', () => {
+    render(
+      <select selectedIndex={-1}>
+        <option value="0">Leonardo</option>
+        <option value="1">Donatello</option>
+        <option value="2">Rafael</option>
+        <option value="3">Michelangelo</option>
+        <option value="4">Splinter</option>
+      </select>,
+      container
+    );
+
+    const select = container.firstElementChild;
+    expect(select.getAttribute('selectedIndex')).toBe(null);
+  });
 });

--- a/packages/inferno/src/DOM/props.ts
+++ b/packages/inferno/src/DOM/props.ts
@@ -82,6 +82,7 @@ export function patchProp(prop, lastValue, nextValue, dom: Element, isSVG: boole
     case 'key':
     case 'multiple':
     case 'ref':
+    case 'selectedIndex':
       break;
     case 'autoFocus':
       (dom as any).autofocus = !!nextValue;


### PR DESCRIPTION
 *Before* submitting a PR please:
 - Include tests for the functionality you are adding! See CONTRIBUTING.md for details how to run tests.
 - Run `npm run build` and check that the build succeeds.
 - Ensure that the PR hasn't been submitted before.

---

Problem: Attribute `selectedIndex` rendered into node `select` when this option passed. It's not needed

![image](https://user-images.githubusercontent.com/37663273/56665635-150f1580-66b3-11e9-9b4d-3abaec6b3ed9.png)

It was introduced here: https://github.com/infernojs/inferno/pull/1425

To fix it added property `selectedIndex` to list of ignored properties of function `patchProp`
