### PR TITLE
"Node" is undefined on IE8

### DIFF
--- a/packages/inferno/src/DOM/rendering.ts
+++ b/packages/inferno/src/DOM/rendering.ts
@@ -25,8 +25,10 @@ if (hasDocumentAvailable) {
    * Defining $EV and $V properties on Node.prototype
    * fixes v8 "wrong map" de-optimization
    */
-  (Node.prototype as any).$EV = null;
-  (Node.prototype as any).$V = null;
+  if (window.Node) {
+    (Node.prototype as any).$EV = null;
+    (Node.prototype as any).$V = null;
+  }
 }
 
 export function __render(


### PR DESCRIPTION
Browser simply fails to initialize the script because Node is undefined on IE8.

The exact spot where it fails is here:
https://github.com/infernojs/inferno/blob/f0d010daee5010545a3016078d1503e30511885b/packages/inferno/src/DOM/rendering.ts#L28-L29

**Expected Current Behaviour**

This spot has to be enclosed into if clause, checking for undefined, like this:

```js
if (window.Node) {
  (Node.prototype as any).$EV = null;
  (Node.prototype as any).$V = null;
}
```

**Inferno Metadata**

Confirmed on:

- IE 8 / Windows 7
- IE 8 / Linux/Wine / BYOND 512.x (because that's where we are trying to roll Inferno).
