### PR TITLE
Fix typings for inferno-redux Provider component

### DIFF
--- a/packages/inferno-redux/__tests__/components/Provider.typings.tsx
+++ b/packages/inferno-redux/__tests__/components/Provider.typings.tsx
@@ -18,7 +18,6 @@ describe('Component typings', () => {
 
   afterEach(function() {
     render(null, container);
-    container.innerHTML = '';
     document.body.removeChild(container);
   });
 
@@ -30,6 +29,7 @@ describe('Component typings', () => {
     const store = createStore(rootReducer);
 
     render(<Provider store={store}></Provider>, container);
+    expect(container.innerHTML).toBe('');
   });
 
   it('should accept store with custom action type', () => {
@@ -50,13 +50,13 @@ describe('Component typings', () => {
     const store = createStore(rootReducer);
 
     render(<Provider store={store}></Provider>, container);
+    expect(container.innerHTML).toBe('');
   });
 
   it('should accept children', () => {
     const HelloComponent = () => <p>Hello my friends!</p>;
 
-    // tslint:disable-next-line: no-empty
-    const store = createStore(() => {});
+    const store = createStore(() => ({}));
 
     render(
       <Provider store={store}>
@@ -66,5 +66,6 @@ describe('Component typings', () => {
       </Provider>,
       container
     );
+    expect(container.innerHTML).toBe('<h1>Hello Page</h1><p>Hello my friends!</p><p>Another greetings!</p>');
   });
 });

--- a/packages/inferno-redux/__tests__/components/Provider.typings.tsx
+++ b/packages/inferno-redux/__tests__/components/Provider.typings.tsx
@@ -1,0 +1,70 @@
+import { AnyAction, createStore } from 'redux';
+
+import { render } from 'inferno';
+import { Provider } from 'inferno-redux';
+
+describe('Component typings', () => {
+  // Basic app state for typing reducer arguments.
+  interface AppState {
+    posts?: string[];
+  }
+
+  let container: Element;
+
+  beforeEach(function() {
+    container = document.createElement('div');
+    document.body.appendChild(container);
+  });
+
+  afterEach(function() {
+    render(null, container);
+    container.innerHTML = '';
+    document.body.removeChild(container);
+  });
+
+  it('should accept store with default action type', () => {
+    const rootReducer = (state: AppState = {}, _: AnyAction) => {
+      return state;
+    };
+
+    const store = createStore(rootReducer);
+
+    render(<Provider store={store}></Provider>, container);
+  });
+
+  it('should accept store with custom action type', () => {
+    // Some custom action interfaces
+    interface FetchPostsAction {
+      type: 'FETCH_ACTION';
+      data: string;
+    }
+
+    interface ReceivePostsAction {
+      type: 'RECEIVE_ACTION';
+      data: string;
+    }
+
+    type MyAction = FetchPostsAction | ReceivePostsAction;
+
+    const rootReducer = (state: AppState = {}, _: MyAction) => state;
+    const store = createStore(rootReducer);
+
+    render(<Provider store={store}></Provider>, container);
+  });
+
+  it('should accept children', () => {
+    const HelloComponent = () => <p>Hello my friends!</p>;
+
+    // tslint:disable-next-line: no-empty
+    const store = createStore(() => {});
+
+    render(
+      <Provider store={store}>
+        <h1>Hello Page</h1>
+        <HelloComponent />
+        <p>Another greetings!</p>
+      </Provider>,
+      container
+    );
+  });
+});

--- a/packages/inferno-redux/src/components/Provider.ts
+++ b/packages/inferno-redux/src/components/Provider.ts
@@ -1,5 +1,5 @@
 import { Component, VNode } from 'inferno';
-import { AnyAction, Store } from 'redux';
+import { Action, AnyAction, Store } from 'redux';
 import { warning } from '../utils/warning';
 
 let didWarnAboutReceivingStore = false;
@@ -13,16 +13,16 @@ const warnAboutReceivingStore = () => {
   warning('<Provider> does not support changing `store` on the fly.');
 };
 
-export interface Props {
-  store: Store<any>;
-  children?: VNode | null | undefined;
+export interface Props<A extends Action = AnyAction> {
+  store: Store<any, A>;
+  children?: VNode | null;
 }
 
-export class Provider extends Component<Props, null> {
+export class Provider<A extends Action = AnyAction> extends Component<Props<A>, null> {
   public static displayName = 'Provider';
-  private readonly store: Store<any, AnyAction | any>;
+  private readonly store: Props<A>['store'];
 
-  constructor(props: Props, context: any) {
+  constructor(props: Props<A>, context: any) {
     super(props, context);
     this.store = props.store;
   }
@@ -35,7 +35,7 @@ export class Provider extends Component<Props, null> {
     return this.props.children;
   }
 
-  public componentWillReceiveProps?(nextProps: Props, nextContext: any): void;
+  public componentWillReceiveProps?(nextProps: Props<A>, nextContext: any): void;
 }
 
 if (process.env.NODE_ENV !== 'production') {

--- a/packages/inferno-redux/src/components/Provider.ts
+++ b/packages/inferno-redux/src/components/Provider.ts
@@ -20,7 +20,7 @@ export interface Props<A extends Action = AnyAction> {
 
 export class Provider<A extends Action = AnyAction> extends Component<Props<A>, null> {
   public static displayName = 'Provider';
-  private readonly store: Props<A>['store'];
+  private readonly store: Store<any, A>;
 
   constructor(props: Props<A>, context: any) {
     super(props, context);
@@ -31,7 +31,9 @@ export class Provider<A extends Action = AnyAction> extends Component<Props<A>, 
     return { store: this.store, storeSubscription: null };
   }
 
-  public render() {
+  // Don't infer the return type. It may be expanded and cause reference errors
+  // in the output.
+  public render(): InfernoNode | undefined {
     return this.props.children;
   }
 

--- a/packages/inferno-redux/src/components/Provider.ts
+++ b/packages/inferno-redux/src/components/Provider.ts
@@ -1,4 +1,4 @@
-import { Component, VNode } from 'inferno';
+import { Component, InfernoNode } from 'inferno';
 import { Action, AnyAction, Store } from 'redux';
 import { warning } from '../utils/warning';
 
@@ -15,7 +15,7 @@ const warnAboutReceivingStore = () => {
 
 export interface Props<A extends Action = AnyAction> {
   store: Store<any, A>;
-  children?: VNode | null;
+  children?: InfernoNode;
 }
 
 export class Provider<A extends Action = AnyAction> extends Component<Props<A>, null> {


### PR DESCRIPTION
**Objective**

This PR fixes some typing issues encountered when using `inferno` and `inferno-redux` in TypeScript environments.

The **first fix** fixes a typing issue that occurs when the root reducer function's second argument is not `AnyAction`. Previously `Provider` will reject any Redux `Store<S, A>` when `A` is not `AnyAction` unless it has been type casted as such. This fix was mostly copied from how `@types/react-redux` handles it.

The **second fix** fixes a type intersection issue caused by this interface https://github.com/infernojs/inferno/blob/deccbe52e60eeaa070db580c6e84f7e225e25811/packages/inferno-redux/src/components/Provider.ts#L16-L19
being passed here (aliased as `P`): https://github.com/infernojs/inferno/blob/deccbe52e60eeaa070db580c6e84f7e225e25811/packages/inferno/src/core/component.ts#L120-L122

This leads to the type of `props.children` to be:
```typescript
VNode | (string & VNode) | (number & VNode) | (false & VNode) | (true & VNode) | (InfernoElement<any> & VNode) | (import("../../../inferno/src").InfernoNodeArray & VNode) | (JSX.Element & VNode) | null | undefined
```
Types like `string & VNode` and `true & VNode` is likely incorrect. I have been unable to determine why `VNode` was given as the type for `Props['children']`, but it seems to be an error and I've changed this to `InfernoNode`.

The **last fix** manually specifies the type of `Provider#render()` as a workaround for #1460. Without that line, TypeScript may infer the type and expand the `InfernoNode` type alias during `.d.ts` generation, leading to an incorrect in-place import for `InfernoNodeArray` to be generated. 

**Closes Issue**

It closes Issue #1460.
