### PR TITLE
Support array and fragment during SSR

### DIFF
--- a/packages/inferno-server/__tests__/creation-queuestream.spec.server.jsx
+++ b/packages/inferno-server/__tests__/creation-queuestream.spec.server.jsx
@@ -377,6 +377,43 @@ describe('SSR Creation Queue Streams - (non-JSX)', () => {
         </div>
       ),
       result: '<div><br></div>'
+    },
+    {
+      description: 'You should be able to render an array',
+      template: () => (
+        [
+          <p>1</p>,
+          <p>2</p>,
+          <p>3</p>
+        ]
+      ),
+      result: '<p>1</p><p>2</p><p>3</p>'
+    },
+    {
+      description: 'You should be able to render an empty array',
+      template: () => [],
+      result: '<!--!-->'
+    },
+    {
+      description: 'You should be able to render a fragment',
+      template: () => (
+        <>
+          <p>1</p>
+          <p>2</p>
+          <p>3</p>
+        </> /* reset syntax highlighting */
+      ),
+      result: '<p>1</p><p>2</p><p>3</p>'
+    },
+    {
+      description: 'You should be able to render an empty fragment',
+      template: () => (<></>), /* reset syntax highlighting */
+      result: '<!--!-->'
+    },
+    {
+      description: 'You should be able to render fragment with single child',
+      template: () => (<><p>1</p></>), /* reset syntax highlighting */
+      result: '<p>1</p>'
     }
   ];
 

--- a/packages/inferno-server/__tests__/creation-stream.spec.server.jsx
+++ b/packages/inferno-server/__tests__/creation-stream.spec.server.jsx
@@ -290,6 +290,43 @@ describe('SSR Creation Streams - (non-JSX)', () => {
         </div>
       ),
       result: '<div><br></div>'
+    },
+    {
+      description: 'You should be able to render an array',
+      template: () => (
+        [
+          <p>1</p>,
+          <p>2</p>,
+          <p>3</p>
+        ]
+      ),
+      result: '<p>1</p><p>2</p><p>3</p>'
+    },
+    {
+      description: 'You should be able to render an empty array',
+      template: () => [],
+      result: '<!--!-->'
+    },
+    {
+      description: 'You should be able to render a fragment',
+      template: () => (
+        <>
+          <p>1</p>
+          <p>2</p>
+          <p>3</p>
+        </> /* reset syntax highlighting */
+      ),
+      result: '<p>1</p><p>2</p><p>3</p>'
+    },
+    {
+      description: 'You should be able to render an empty fragment',
+      template: () => (<></>), /* reset syntax highlighting */
+      result: '<!--!-->'
+    },
+    {
+      description: 'You should be able to render fragment with single child',
+      template: () => (<><p>1</p></>), /* reset syntax highlighting */
+      result: '<p>1</p>'
     }
   ];
 

--- a/packages/inferno-server/__tests__/creation.spec.server.jsx
+++ b/packages/inferno-server/__tests__/creation.spec.server.jsx
@@ -152,6 +152,43 @@ describe('SSR Creation (JSX)', () => {
         </div>
       ),
       result: '<div><br></div>'
+    },
+    {
+      description: 'You should be able to render an array',
+      template: () => (
+        [
+          <p>1</p>,
+          <p>2</p>,
+          <p>3</p>
+        ]
+      ),
+      result: '<p>1</p><p>2</p><p>3</p>'
+    },
+    {
+      description: 'You should be able to render an empty array',
+      template: () => [],
+      result: '<!--!-->'
+    },
+    {
+      description: 'You should be able to render a fragment',
+      template: () => (
+        <>
+          <p>1</p>
+          <p>2</p>
+          <p>3</p>
+        </> /* reset syntax highlighting */
+      ),
+      result: '<p>1</p><p>2</p><p>3</p>'
+    },
+    {
+      description: 'You should be able to render an empty fragment',
+      template: () => (<></>), /* reset syntax highlighting */
+      result: '<!--!-->'
+    },
+    {
+      description: 'You should be able to render fragment with single child',
+      template: () => (<><p>1</p></>), /* reset syntax highlighting */
+      result: '<p>1</p>'
     }
   ];
 

--- a/packages/inferno-server/src/renderToString.queuestream.ts
+++ b/packages/inferno-server/src/renderToString.queuestream.ts
@@ -284,20 +284,18 @@ export class RenderQueueStream extends Readable {
       this.addToQueue(children === '' ? ' ' : escapeText(children), position);
       // Handle fragments and arrays
     } else if (isArray(vNode) || (flags & VNodeFlags.Fragment) !== 0) {
-
       const childFlags = vNode.childFlags;
     
       if (childFlags === ChildFlags.HasVNodeChildren || (isArray(vNode) && vNode.length === 0)) {
         this.addToQueue ('<!--!-->', position);
       } else if (childFlags & ChildFlags.MultipleChildren || isArray(vNode)) {
-        const children = isArray(vNode) ? vNode : vNode.children;
+        const tmpChildren = isArray(vNode) ? vNode : vNode.children;
         
-        for (let i = 0, len = children.length; i < len; ++i) {
-          this.renderVNodeToQueue(children[i], context, position);
+        for (let i = 0, len = tmpChildren.length; i < len; ++i) {
+          this.renderVNodeToQueue(tmpChildren[i], context, position);
         }
         return;
       }
-
       // Handle errors
     } else {
       if (process.env.NODE_ENV !== 'production') {

--- a/packages/inferno-server/src/renderToString.ts
+++ b/packages/inferno-server/src/renderToString.ts
@@ -1,6 +1,7 @@
 import {EMPTY_OBJ} from 'inferno';
 import {
   combineFrom,
+  isArray,
   isFunction,
   isInvalid,
   isNull,
@@ -180,16 +181,17 @@ function renderVNodeToString(vNode, parent, context): string {
     return renderedString;
   } else if ((flags & VNodeFlags.Text) !== 0) {
     return children === '' ? ' ' : escapeText(children);
-  } else if ((flags & VNodeFlags.Fragment) !== 0) {
+  } else if (isArray(vNode) || (flags & VNodeFlags.Fragment) !== 0) {
     const childFlags = vNode.childFlags;
-
-    if (childFlags === ChildFlags.HasVNodeChildren) {
+    
+    if (childFlags === ChildFlags.HasVNodeChildren || (isArray(vNode) && vNode.length === 0)) {
       return '<!--!-->';
-    } else if (childFlags & ChildFlags.MultipleChildren) {
+    } else if (childFlags & ChildFlags.MultipleChildren || isArray(vNode)) {
+      const tmpNodes = isArray(vNode) ? vNode : children;
       let renderedString = '';
-
-      for (let i = 0, len = children.length; i < len; ++i) {
-        renderedString += renderVNodeToString(children[i], vNode, context);
+      
+      for (let i = 0, len = tmpNodes.length; i < len; ++i) {
+        renderedString += renderVNodeToString(tmpNodes[i], vNode, context);
       }
 
       return renderedString;


### PR DESCRIPTION
Added tests and implementation. Used existing code path for rendering fragments where available.

This PR closes #1501 

I noticed that the tests for the three rendering methods were in separate files. This allowed them to have different feature support (fragment was missing in two). I have opened a ticket https://github.com/infernojs/inferno/issues/1502