### PR TITLE
Optimised renderToString and streamQueueAsString for performance

### DIFF
--- a/packages/inferno-server/__tests__/performance.server.jsx
+++ b/packages/inferno-server/__tests__/performance.server.jsx
@@ -1,0 +1,189 @@
+import { renderToStaticMarkup, renderToString } from 'inferno-server';
+import { Component, createFragment } from 'inferno';
+import { createElement } from 'inferno-create-element';
+import { ChildFlags } from 'inferno-vnode-flags';
+import { hydrate } from 'inferno-hydrate';
+//import { performance } from 'perf_hooks';
+
+function WrappedInput(props) {
+  return <input type="text" value={props.value} />;
+}
+
+function WithChild(props) {
+  return <div>{props.children}</div>
+}
+
+describe('SSR Creation (JSX)', () => {
+  const testEntries = [
+    {
+      template: (props) => <div>{null}</div>,
+    },
+    {
+      template: (props) => (
+        <div>
+          {null}
+          <span>emptyValue: {null}</span>
+        </div>
+      ),
+    },
+    {
+      template: (props) => <script src="foo" async />,
+    },
+    {
+      template: (props) => (
+        <div>
+          Hello world, {'1'}2{'3'}
+        </div>
+      ),
+    },
+    {
+      template: (props) => <div>"Hello world"</div>,
+    },
+    {
+      template: (props) => <div>Hello world, {/* comment*/}</div>,
+    },
+    {
+      template: (props) => <div>{[null, '123', null, '456']}</div>,
+    },
+    {
+      template: (props) => <p children="foo">foo</p>,
+    },
+    {
+      template: (props) => <input value="bar" />,
+    },
+    {
+      template: (props) => <input value="bar" defaultValue="foo" />,
+    },
+    {
+      template: (props) => <input defaultValue="foo" />,
+    },
+    {
+      template: (props) => <input defaultValue={123} />,
+    },
+    {
+      template: (props) => <WrappedInput value="foo" />,
+    },
+    {
+      template: (props) => (
+        <select value="dog">
+          <option value="cat">A cat</option>
+          <option value="dog">A dog</option>
+        </select>
+      ),
+    },
+    {
+      template: (props) => (
+        <div>
+          <div>{''}</div>
+          <div>{props.children}</div>
+          <p>Test</p>
+        </div>
+      ),
+    },
+    {
+      template: (props) => <div style={{ 'background-color': 'red', 'border-bottom-color': 'green' }} />,
+    },
+    {
+      template: (props) => <div style={{ 'background-color': null, 'border-bottom-color': null }} />,
+    },
+    {
+      template: (props) => <div style={null}>{props.children}</div>,
+    },
+    {
+      template: (props) => createElement('div', null, 'Hello world <img src="x" onerror="alert(\'&XSS&\')">'),
+    },
+    {
+      template: (props) => <div style={{ opacity: 0.8 }} />,
+    },
+    {
+      template: (props) => <div style="opacity:0.8;">{props.children}</div>,
+    },
+    {
+      template: (props) => <div className={123} />,
+    },
+    {
+      template: (props) => <input defaultValue={123} />,
+    },
+    {
+      template: (props) => (
+        <div>
+          <br />
+          {props.children}
+        </div>
+      ),
+    },
+    {
+      template: (props) => (
+        [
+          <p>1</p>,
+          <p>2</p>,
+          <p>3</p>
+        ]
+      ),
+    },
+    {
+      template: (props) => [],
+    },
+    {
+      template: (props) => (
+        <>
+          <p>1</p>
+          <p>2</p>
+          <p>3</p>
+        </> /* reset syntax highlighting */
+      ),
+    },
+    {
+      template: (props) => (<></>), /* reset syntax highlighting */
+    },
+    {
+      template: (props) => (<>{props.children}</>), /* reset syntax highlighting */
+    }
+  ];
+
+  function getVDom(depth) {
+    if (depth === 0) {
+      return null
+    }
+
+    return <WithChild>{testEntries.map((item) => item.template(<div>{getVDom(depth - 1)}</div>))}</WithChild>
+  }
+
+  it("Tests performance and memory consumption", () => {
+    let output
+    const vDom = getVDom(4);
+    
+    const imax = 100;
+    const timing = [];
+    const memory = [];
+    for (let i = 0; i++ < imax;) {
+      const start = performance.now();
+      const startMem = process.memoryUsage();
+      
+      for (let j = 0; j++ < 10;) {
+        output = renderToString(vDom);
+      }
+      const end = performance.now();
+      const endMem = process.memoryUsage();
+      timing.push((end - start) / 10);
+      memory.push({
+        heapTotal: (endMem.heapTotal - startMem.heapTotal) / 10 / 1024,
+        heapUsed: (endMem.heapUsed - startMem.heapUsed) / 10 / 1024,
+        external: (endMem.external - startMem.external) / 10 / 1024,
+      })
+    }
+    console.log("Timing: ", timing)
+    console.log("Memory delta: ", memory)
+    
+    expect(typeof output).toBe('string');
+    expect(output.length).toBeGreaterThan(1000);
+    expect(output).toContain('<option value="cat">A cat</option>')
+    /*
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    container.innerHTML = output;
+    expect(output).toBe(test.result);
+    document.body.removeChild(container);
+    */
+  });
+});

--- a/packages/inferno-server/__tests__/performance.server.jsx
+++ b/packages/inferno-server/__tests__/performance.server.jsx
@@ -174,6 +174,13 @@ describe('SSR Creation (JSX)', () => {
     }
     console.log("Timing: ", timing)
     console.log("Memory delta: ", memory)
+
+    console.log("Average: ",
+      Math.round(timing.reduce((prev, curr, i, arr) => prev + curr / arr.length, 0) * 1000) / 1000 + "ms",
+      Math.round(memory.filter((i) => i.heapUsed > 0).reduce((prev, curr, i, arr) => prev + curr.heapUsed / arr.length, 0) * 10) / 10 + "kb",
+      Math.round(memory.reduce((prev, curr, i, arr) => prev + curr.heapUsed / arr.length, 0) * 10) / 10 + "kb"
+    )
+    console.log("(time/call – heap delta/call – heap delta overall")
     
     expect(typeof output).toBe('string');
     expect(output.length).toBeGreaterThan(1000);

--- a/packages/inferno-server/src/renderToString.ts
+++ b/packages/inferno-server/src/renderToString.ts
@@ -14,7 +14,7 @@ import {ChildFlags, VNodeFlags} from 'inferno-vnode-flags';
 import {renderStylesToString} from './prop-renderers';
 import {createDerivedState, escapeText, isAttributeNameSafe, voidElements} from './utils';
 
-function renderVNodeToString(vNode, parent, context): string {
+function renderVNodeToString(ARR, vNode, parent, context): string[] {
   const flags = vNode.flags;
   const type = vNode.type;
   const props = vNode.props || EMPTY_OBJ;
@@ -68,40 +68,47 @@ function renderVNodeToString(vNode, parent, context): string {
       const renderOutput = instance.render(props, instance.state, instance.context);
       // In case render returns invalid stuff
       if (isInvalid(renderOutput)) {
-        return '<!--!-->';
+        ARR.push('<!--!-->');
+        return ARR
       }
       if (isString(renderOutput)) {
-        return escapeText(renderOutput);
+        ARR.push(escapeText(renderOutput));
+        return ARR
       }
       if (isNumber(renderOutput)) {
-        return renderOutput + '';
+        ARR.push(renderOutput + '');
+        return ARR
       }
-      return renderVNodeToString(renderOutput, vNode, childContext);
+      return renderVNodeToString(ARR, renderOutput, vNode, childContext);
     } else {
       const renderOutput = type(props, context);
 
       if (isInvalid(renderOutput)) {
-        return '<!--!-->';
+        ARR.push('<!--!-->');
+        return ARR
       }
       if (isString(renderOutput)) {
-        return escapeText(renderOutput);
+        ARR.push(escapeText(renderOutput));
+        return ARR
       }
       if (isNumber(renderOutput)) {
-        return renderOutput + '';
+        ARR.push(renderOutput + '');
+        return ARR
       }
-      return renderVNodeToString(renderOutput, vNode, context);
+      return renderVNodeToString(ARR, renderOutput, vNode, context);
     }
   } else if ((flags & VNodeFlags.Element) !== 0) {
-    let renderedString = `<${type}`;
+    const _startAt = ARR.length;
+    ARR.push(`<${type}`);
     let html;
 
     const isVoidElement = voidElements.has(type);
     const className = vNode.className;
 
     if (isString(className)) {
-      renderedString += ` class="${escapeText(className)}"`;
+      ARR.push(` class="${escapeText(className)}"`);
     } else if (isNumber(className)) {
-      renderedString += ` class="${className}"`;
+      ARR.push(` class="${className}"`);
     }
 
     if (!isNull(props)) {
@@ -114,7 +121,7 @@ function renderVNodeToString(vNode, parent, context): string {
             break;
           case 'style':
             if (!isNullOrUndef(props.style)) {
-              renderedString += ` style="${renderStylesToString(props.style)}"`;
+              ARR.push(` style="${renderStylesToString(props.style)}"`);
             }
             break;
           case 'children':
@@ -124,23 +131,23 @@ function renderVNodeToString(vNode, parent, context): string {
           case 'defaultValue':
             // Use default values if normal values are not present
             if (!props.value) {
-              renderedString += ` value="${isString(value) ? escapeText(value) : value}"`;
+              ARR.push(` value="${isString(value) ? escapeText(value) : value}"`);
             }
             break;
           case 'defaultChecked':
             // Use default values if normal values are not present
             if (!props.checked) {
-              renderedString += ` checked="${value}"`;
+              ARR.push(` checked="${value}"`);
             }
             break;
           default:
             if (isAttributeNameSafe(prop)) {
               if (isString(value)) {
-                renderedString += ` ${prop}="${escapeText(value)}"`;
+                ARR.push(` ${prop}="${escapeText(value)}"`);
               } else if (isNumber(value)) {
-                renderedString += ` ${prop}="${value}"`;
+                ARR.push(` ${prop}="${value}"`);
               } else if (value === true) {
-                renderedString += ` ${prop}`;
+                ARR.push(` ${prop}`);
               }
             }
 
@@ -149,52 +156,49 @@ function renderVNodeToString(vNode, parent, context): string {
       }
       if (type === 'option' && typeof props.value !== 'undefined' && props.value === parent.props.value) {
         // Parent value sets children value
-        renderedString += ` selected`;
+        ARR.push(` selected`);
       }
     }
     if (isVoidElement) {
-      renderedString += `>`;
+      ARR.push(`>`);
     } else {
-      renderedString += `>`;
+      ARR.push(`>`);
       const childFlags = vNode.childFlags;
 
       if (childFlags === ChildFlags.HasVNodeChildren) {
-        renderedString += renderVNodeToString(children, vNode, context);
+        renderVNodeToString(ARR, children, vNode, context);
       } else if (childFlags & ChildFlags.MultipleChildren) {
         for (let i = 0, len = children.length; i < len; ++i) {
-          renderedString += renderVNodeToString(children[i], vNode, context);
+          renderVNodeToString(ARR, children[i], vNode, context);
         }
       } else if (childFlags === ChildFlags.HasTextChildren) {
-        renderedString += children === '' ? ' ' : escapeText(children);
+        ARR.push(children === '' ? ' ' : escapeText(children));
       } else if (html) {
-        renderedString += html;
+        ARR.push(html);
       }
       if (!isVoidElement) {
-        renderedString += `</${type}>`;
+        ARR.push(`</${type}>`);
       }
     }
 
     if (String(type).match(/[\s\n\/='"\0<>]/)) {
-      throw renderedString;
+      // Throw the html geenerated for this element and remove it from output
+      throw ARR.splice(_startAt, ARR.length - _startAt).join('');
     }
 
-    return renderedString;
   } else if ((flags & VNodeFlags.Text) !== 0) {
-    return children === '' ? ' ' : escapeText(children);
+    ARR.push(children === '' ? ' ' : escapeText(children));
   } else if (isArray(vNode) || (flags & VNodeFlags.Fragment) !== 0) {
     const childFlags = vNode.childFlags;
     
     if (childFlags === ChildFlags.HasVNodeChildren || (isArray(vNode) && vNode.length === 0)) {
-      return '<!--!-->';
+      ARR.push('<!--!-->');
     } else if (childFlags & ChildFlags.MultipleChildren || isArray(vNode)) {
       const tmpNodes = isArray(vNode) ? vNode : children;
-      let renderedString = '';
       
       for (let i = 0, len = tmpNodes.length; i < len; ++i) {
-        renderedString += renderVNodeToString(tmpNodes[i], vNode, context);
+        renderVNodeToString(ARR, tmpNodes[i], vNode, context);
       }
-
-      return renderedString;
     }
   } else {
     if (process.env.NODE_ENV !== 'production') {
@@ -207,9 +211,10 @@ function renderVNodeToString(vNode, parent, context): string {
     throwError();
   }
 
-  return '';
+  return ARR;
 }
 
 export function renderToString(input: any): string {
-  return renderVNodeToString(input, {}, {}) as string;
+  const outp = renderVNodeToString([], input, {}, {})
+  return outp.join("") as string;
 }


### PR DESCRIPTION
Changed from string concat to array with join. Should be much faster and more memory efficient for larger pages. Especially noticeable for renderToString.

This passes all the test, but I haven't added any tests, so would be great if you just look at the actual changes. The SSR-tests don't provide 100% coverage from what I can see, partly due to https://github.com/infernojs/inferno/issues/1502