### PR TITLE
router: fix typing of `IRouteProps.component`

### DIFF
--- a/packages/inferno-router/__tests__/Route.typings.spec.tsx
+++ b/packages/inferno-router/__tests__/Route.typings.spec.tsx
@@ -1,0 +1,33 @@
+import { render } from 'inferno';
+import { Route, Router } from 'inferno-router';
+import createMemoryHistory from 'history/createMemoryHistory';
+
+describe('<Route component>', () => {
+  const history = createMemoryHistory();
+  const node = document.createElement('div');
+
+  it('receives { history, location, match } props', () => {
+    type RouteProps = {
+      history: any;
+      location: any;
+      match: any;
+    };
+    let actual: RouteProps = {
+      history: null,
+      location: null,
+      match: null,
+    };
+    const Component = (props: RouteProps) => (actual = props) && null;
+
+    render(
+      <Router history={history}>
+        <Route path="/" component={Component} />
+      </Router>,
+      node
+    );
+
+    expect(actual.history).toBe(history);
+    expect(typeof actual.match).toBe('object');
+    expect(typeof actual.location).toBe('object');
+  });
+});

--- a/packages/inferno-router/src/Route.ts
+++ b/packages/inferno-router/src/Route.ts
@@ -25,7 +25,7 @@ export interface IRouteProps {
   exact?: boolean;
   strict?: boolean;
   sensitive?: boolean;
-  component?: IComponentConstructor<any> | SFC;
+  component?: IComponentConstructor<any> | SFC<any>;
   render?: (props: RouteComponentProps<any>, context: any) => InfernoNode;
   location?: H.Location;
   children?: ((props: RouteComponentProps<any>) => InfernoNode) | InfernoNode;


### PR DESCRIPTION
**Objective**

This PR fixes a typing issue of `Route` and functional components.

Passing a class based component has no problem, but a functional component accepting `{match}` causes errors.

Example:

```tsx
const Todos = ({match}:{match:any}) => {
  return <div>item id: {match.params.id} </div>
}

const App = () => {
  return <Route path="/todos/:id" component={Play} />  // error TS2322: not assignable
}
```

The issue seems to be caused by this code:

https://github.com/infernojs/inferno/blob/c546eb556a97577d0b873fb3b69a97b014374ec0/packages/inferno-router/src/Route.ts#L22-L32

`SFC` should have `<any>` as same as `IComponentConstructor` , so this PR fixes it.
