### PR TITLE
replace slave label with replica

### DIFF
--- a/docs/dbmonster/ENV.js
+++ b/docs/dbmonster/ENV.js
@@ -139,14 +139,14 @@ var ENV = ENV || (function () {
 			data = [];
 			for (var i = 1; i <= ENV.rows; i++) {
 				data.push({ dbname: 'cluster' + i, query: "", formatElapsed: "", elapsedClassName: "" });
-				data.push({ dbname: 'cluster' + i + ' slave', query: "", formatElapsed: "", elapsedClassName: "" });
+				data.push({ dbname: 'cluster' + i + ' replica', query: "", formatElapsed: "", elapsedClassName: "" });
 			}
 		}
 		if (!data) { // first init when keepIdentity
 			data = [];
 			for (var i = 1; i <= ENV.rows; i++) {
 				data.push({ dbname: 'cluster' + i });
-				data.push({ dbname: 'cluster' + i + ' slave' });
+				data.push({ dbname: 'cluster' + i + ' replica' });
 			}
 			oldData = data;
 		}


### PR DESCRIPTION
**Objective**

One of the example is using the antiquated word "slave" for a database replica. I updated the language and tested the change.

PS: [previously merged change in mithril](https://github.com/MithrilJS/mithril.js/pull/2605)