### PR TITLE
Fixing type errors

### DIFF
--- a/packages/inferno-router/src/NavLink.ts
+++ b/packages/inferno-router/src/NavLink.ts
@@ -13,14 +13,14 @@ function filter(i) {
  */
 export function NavLink({
   to,
-  exact,
-  strict,
-  onClick,
+  exact = false,
+  strict = false,
+  onClick = null,
   location: linkLocation,
   activeClassName = 'active',
-  className,
-  activeStyle,
-  style,
+  className = null,
+  activeStyle = null,
+  style = null,
   isActive: getIsActive,
   ariaCurrent = 'true',
   ...rest
@@ -34,10 +34,12 @@ export function NavLink({
       combineFrom(
         {
           'aria-current': isActive && ariaCurrent,
-          className: isActive ? [className, activeClassName].filter(filter).join(' ') : className,
+          className: isActive
+            ? [className, activeClassName].filter(filter).join(' ')
+            : className,
           onClick,
           style: isActive ? combineFrom(style, activeStyle) : style,
-          to
+          to,
         },
         rest
       )
@@ -49,6 +51,6 @@ export function NavLink({
     exact,
     location: linkLocation,
     path: typeof to === 'object' ? to.pathname : to,
-    strict
+    strict,
   });
 }


### PR DESCRIPTION
**Objective**

The objective of this PR is to be able to create a `<NavLink>` without all of the attributes, while not getting a TypeScript error.

**Closes Issue**

This PR is meant to close #1518.

**Context**

I was trying to fix this, but I think I'm a bit of a newbie in TypeScript. The main issue I'm having is that the type signature is this one:

```typescript
export function NavLink({
  to,
  exact,
  strict,
  onClick,
  location: linkLocation,
  activeClassName = 'active',
  className,
  activeStyle,
  style,
  isActive: getIsActive,
  ariaCurrent = 'true',
  ...rest
}): any {
```

The issue is that if some of those are not mandatory, I get the following TypeScript error:
```
binding pattern parameter can't be optional in an implementation parameter
```

I have read that you must specify a default value for this to work, and I tried the following:
```typescript
export function NavLink({
  to,
  exact = false,
  strict = false,
  onClick = null,
  location: linkLocation,
  activeClassName = 'active',
  className = null,
  activeStyle = null,
  style = null,
  isActive: getIsActive,
  ariaCurrent = 'true',
  ...rest
}): any {
```

But I cannot check if this works, since using `inferno` as a local dependency seems to be creating a ton of errors.