### PR TITLE
docs: Fix simple typo, succesfully -> successfully

### DIFF
--- a/README.md
+++ b/README.md
@@ -862,7 +862,7 @@ All these Component lifecycle methods ( including `render` and `setState - callb
 
 | Name                              | Triggered when                                                                        | Arguments to callback           |
 | -----------                       | --------------                                                                        | -----------------------         |
-| `componentDidMount`               | component has been mounted succesfully                                                |                                 |
+| `componentDidMount`               | component has been mounted successfully                                                |                                 |
 | `componentWillMount`              | component is about to mount                                                           |                                 |
 | `componentWillReceiveProps`       | before render when component updates                                                  | `nextProps, context`            |
 | `shouldComponentUpdate`           | component has been triggered to update                                                | `nextProps, nextState`          |

--- a/packages/inferno/README.md
+++ b/packages/inferno/README.md
@@ -860,7 +860,7 @@ All these Component lifecycle methods ( including `render` and `setState - callb
 
 | Name                              | Triggered when                                                                        | Arguments to callback           |
 | -----------                       | --------------                                                                        | -----------------------         |
-| `componentDidMount`               | component has been mounted succesfully                                                |                                 |
+| `componentDidMount`               | component has been mounted successfully                                                |                                 |
 | `componentWillMount`              | component is about to mount                                                           |                                 |
 | `componentWillReceiveProps`       | before render when component updates                                                  | `nextProps, context`            |
 | `shouldComponentUpdate`           | component has been triggered to update                                                | `nextProps, nextState`          |


### PR DESCRIPTION
There is a small typo in README.md, packages/inferno/README.md.

Should read `successfully` rather than `succesfully`.

