### PR TITLE
Added new npm scripts to reduce compile time when developing

### DIFF
--- a/README.md
+++ b/README.md
@@ -987,6 +987,14 @@ $ npm run build
 $ npm run test:browser
 ```
 
+If you only want to run the browser tests when coding, use the following to reduce turnaround by 50-80%:
+
+```sh
+$ npm run quick-test:browser # Compiles all packages and runs browser tests
+$ npm run quick-test:browser-inferno # Only compiles the inferno package and runs browser tests
+$ npm run quick-test:browser-debug # Compiles all packages and runs browser tests with "debug"
+```
+
 ## Community
 
 There is an [Inferno Slack](https://infernojs.slack.com). You can join via [inferno-slack.herokuapp.com](https://inferno-slack.herokuapp.com).

--- a/package.json
+++ b/package.json
@@ -74,9 +74,13 @@
     "test:browser:compat": "cross-env InfernoCompat=1 npm run --prefix fixtures/browser local",
     "test:browser:nocompat": "cross-env InfernoCompat=0 npm run --prefix fixtures/browser local",
     "test:browser:debug": "cross-env InfernoCompat=1 npm run --prefix fixtures/browser debug",
+    "test:browser:debug-nocompat": "cross-env InfernoCompat=0 npm run --prefix fixtures/browser debug",
     "test:browser:sauce": "npm run --prefix fixtures/browser test",
     "test:react": "npm run --prefix fixtures/react test -- --forceExit",
-    "test:package": "node fixtures/packaging/build-all.js"
+    "test:package": "node fixtures/packaging/build-all.js",
+    "quick-test:browser": "run-s build:s:** && npm run build:p:cjs:prod && npm run test:browser:nocompat",
+    "quick-test:browser:debug": "run-s build:s:** && npm run build:p:cjs:prod && npm run test:browser:debug-nocompat",
+    "quick-test:browser-inferno": "lerna exec --scope 'inferno' tsc -- --noEmit && lerna exec --scope 'inferno' -- node ../../scripts/rollup/build.js --name=index --ext=.dev.esm.js --env=development --format=es --minify=false && lerna exec --scope 'inferno' -- node ../../scripts/rollup/build.js --env=production --format=cjs --replace=true --name=index.cjs --minify=true --ext=.min.js && npm run test:browser:nocompat"
   },
   "devDependencies": {
     "@babel/core": "^7.12.16",


### PR DESCRIPTION
Added some convenient npm scripts to improve the development experience. These scripts can be used to quickly run browser tests during development. Sorry about the package.json pollution, but it was already quite busy.

This doesn't use esbuild because more work needs to be done to get it working, I just identified the least amount of actions needed to run the tests and broke that out. 