### PR TITLE
Some minor improvements to inferno-animation including possible fix to strict mode issue

### DIFF
--- a/examples/animations/app.js
+++ b/examples/animations/app.js
@@ -108,18 +108,18 @@
 
       // 3. Set an animation listener, code at end
       // Needs to be done after activating so timeout is calculated correctly
-      registerTransitionListener([dom, dom.children[0]], function () {
+      registerTransitionListener([dom], function () {
         // *** Cleanup ***
         // 5. Remove the element
         removeClassName(dom, animCls.active)
         removeClassName(dom, animCls.end)
-      }, false)
+      })
 
       // 4. Activate target state
-      setTimeout(() => {
+      requestAnimationFrame(() => {
         removeClassName(dom, animCls.start)
         addClassName(dom, animCls.end)
-      }, 5)
+      })
     }
 
     componentWillDisappear = (dom, callback) => {
@@ -137,7 +137,7 @@
 
       // 3. Set an animation listener, code at end
       // Needs to be done after activating so timeout is calculated correctly
-      registerTransitionListener(dom, function () {
+      registerTransitionListener([dom], function () {
         // *** Cleanup ***
 
         // Simulate some work is being done
@@ -145,13 +145,13 @@
         //   callback();
         // }, 1000);
         callback();
-      }, false)
+      })
 
       // 4. Activate target state
-      setTimeout(() => {
+      requestAnimationFrame(() => {
         addClassName(dom, animCls.end)
         removeClassName(dom, animCls.start)
-      }, 5)
+      })
     }
 
     doRemove = (e, index) => {

--- a/packages/inferno-animation/src/AnimatedComponent.ts
+++ b/packages/inferno-animation/src/AnimatedComponent.ts
@@ -45,7 +45,7 @@ export class AnimatedComponent<P = {}, S = {}> extends Component<AnimationProp &
     // 3. Set an animation listener, code at end
     // Needs to be done after activating so timeout is calculated correctly
     registerTransitionListener(
-      [dom, dom.children[0]],
+      [dom],
       function () {
         // *** Cleanup ***
         // 5. Remove the element
@@ -56,8 +56,7 @@ export class AnimatedComponent<P = {}, S = {}> extends Component<AnimationProp &
         // 6. Call callback to allow stuff to happen
         // Not currently used but this is where one could
         // add a call to something like this.didAppearDone
-      },
-      false
+      }
     );
 
     // 4. Activate target state
@@ -82,12 +81,11 @@ export class AnimatedComponent<P = {}, S = {}> extends Component<AnimationProp &
     // 3. Set an animation listener, code at end
     // Needs to be done after activating so timeout is calculated correctly
     registerTransitionListener(
-      dom,
+      [dom],
       function () {
         // *** Cleanup not needed since node is removed ***
         callback();
-      },
-      false
+      }
     );
 
     // 4. Activate target state

--- a/packages/inferno-animation/src/utils.ts
+++ b/packages/inferno-animation/src/utils.ts
@@ -178,12 +178,6 @@ function setAnimationTimeout(onTransitionEnd, rootNode, maxDuration) {
  * will be animations that fail to complete before the timeout is triggered.
  */
 export function registerTransitionListener(nodes: HTMLElement[], callback: Function, noTimeout: boolean = false) {
-  if (!Array.isArray(nodes)) {
-    nodes = [nodes];
-  } else {
-    // Make sure we don't have undefined nodes (happens when an animated el doesn't have children)
-    nodes = nodes.filter((node) => node);
-  }
   const rootNode = nodes[0];
 
   /**
@@ -204,7 +198,8 @@ export function registerTransitionListener(nodes: HTMLElement[], callback: Funct
       // Make sure it isn't a child that is triggering the event
       let goAhead = false;
       for (let i = 0; i < nodes.length; i++) {
-        if (event.target === nodes[i]) {
+        // Note: Check for undefined nodes (happens when an animated el doesn't have children)
+        if (nodes[i] !== undefined && event.target === nodes[i]) {
           goAhead = true;
           break;
         }

--- a/packages/inferno-animation/src/utils.ts
+++ b/packages/inferno-animation/src/utils.ts
@@ -188,7 +188,7 @@ export function registerTransitionListener(nodes: HTMLElement[], callback: Funct
   let nrofTransitionsLeft = transitionDuration.nrofTransitions;
   let done = false;
 
-  function onTransitionEnd(event) {
+  const onTransitionEnd = (event) => {
     // Make sure this is an actual event
     if (!event || done) {
       return;

--- a/packages/inferno-animation/src/utils.ts
+++ b/packages/inferno-animation/src/utils.ts
@@ -160,7 +160,7 @@ const transitionEndName: string = (function () {
   }
 })();
 
-function debugAnimations(onTransitionEnd, rootNode, maxDuration) {
+function setAnimationTimeout(onTransitionEnd, rootNode, maxDuration) {
   if (rootNode.nodeName === 'IMG' && !(rootNode as any).complete) {
     // Image animations should wait for loaded until the timeout is started, otherwise animation will be cut short
     // due to loading delay
@@ -234,7 +234,7 @@ export function registerTransitionListener(nodes: HTMLElement[], callback: Funct
   // Fallback if transitionend fails
   // This is disabled during debug so we can set breakpoints
   if (!(process.env.NODE_ENV !== 'production' && isDebugAnimationsSet()) && !noTimeout) {
-    debugAnimations(onTransitionEnd, rootNode, maxDuration);
+    setAnimationTimeout(onTransitionEnd, rootNode, maxDuration);
   }
 }
 

--- a/packages/inferno-animation/src/utils.ts
+++ b/packages/inferno-animation/src/utils.ts
@@ -1,4 +1,4 @@
-import { isFunction, isString } from 'inferno-shared';
+import { isFunction, isString, warning } from 'inferno-shared';
 
 declare global {
   // Setting `window.__DEBUG_ANIMATIONS__ = true;` disables animation timeouts
@@ -176,8 +176,11 @@ function setAnimationTimeout(onTransitionEnd, rootNode, maxDuration) {
  * You need to pass the root element and ALL animated children that have transitions,
  * if there are any,  so the timeout is set to the longest duration. Otherwise there
  * will be animations that fail to complete before the timeout is triggered.
+ * 
+ * @param nodes a list of nodes that have transitions that are part of this animation
+ * @param callback callback when all transitions of participating nodes are completed
  */
-export function registerTransitionListener(nodes: HTMLElement[], callback: Function, noTimeout: boolean = false) {
+export function registerTransitionListener(nodes: HTMLElement[], callback: Function) {
   const rootNode = nodes[0];
 
   /**
@@ -228,8 +231,12 @@ export function registerTransitionListener(nodes: HTMLElement[], callback: Funct
 
   // Fallback if transitionend fails
   // This is disabled during debug so we can set breakpoints
-  if (!(process.env.NODE_ENV !== 'production' && isDebugAnimationsSet()) && !noTimeout) {
+  // WARNING: If the callback isn't called, the DOM nodes won't be removed
+  if (!(process.env.NODE_ENV !== 'production' && isDebugAnimationsSet())) {
     setAnimationTimeout(onTransitionEnd, rootNode, maxDuration);
+  }
+  else if (process.env.NODE_ENV !== 'production') {
+    warning('You are in animation debugging mode and fallback timeouts aren\'t set. DOM nodes could be left behind.')
   }
 }
 


### PR DESCRIPTION
Some cleanup of code and minor performance improvements. Added a warning when in development mode and activating  __INFERNO_ANIMATION_DEBUG__.

I believe I have fixed the issue with creating a function within a function that caused errors in some older browsers due to strict mode. I had no good way of testing so we need to monitor the results of the CD/CI-tests.