### PR TITLE
Animation hooks functional components

### DIFF
--- a/examples/animations/app.css
+++ b/examples/animations/app.css
@@ -150,6 +150,17 @@ h1 {
   transform-origin: 50% 50%;
 }
 
+h1 small {
+  font-size: 0.5em;
+}
+h1 small a {
+  color: #4A90E2;
+  text-decoration: none;
+}
+h1 small a:hover {
+  color: #3775bb;;
+}
+
 h2 {
   font-size: 1rem;
   font-weight: 100;

--- a/examples/animations/app.js
+++ b/examples/animations/app.js
@@ -108,18 +108,18 @@
 
       // 3. Set an animation listener, code at end
       // Needs to be done after activating so timeout is calculated correctly
-      registerTransitionListener([dom, dom.children[0]], function () {
+      registerTransitionListener([dom], function () {
         // *** Cleanup ***
         // 5. Remove the element
         removeClassName(dom, animCls.active)
         removeClassName(dom, animCls.end)
-      }, false)
+      })
 
       // 4. Activate target state
-      setTimeout(() => {
+      requestAnimationFrame(() => {
         removeClassName(dom, animCls.start)
         addClassName(dom, animCls.end)
-      }, 5)
+      })
     }
 
     componentWillDisappear = (dom, callback) => {
@@ -137,7 +137,7 @@
 
       // 3. Set an animation listener, code at end
       // Needs to be done after activating so timeout is calculated correctly
-      registerTransitionListener(dom, function () {
+      registerTransitionListener([dom], function () {
         // *** Cleanup ***
 
         // Simulate some work is being done
@@ -145,13 +145,13 @@
         //   callback();
         // }, 1000);
         callback();
-      }, false)
+      })
 
       // 4. Activate target state
-      setTimeout(() => {
+      requestAnimationFrame(() => {
         addClassName(dom, animCls.end)
         removeClassName(dom, animCls.start)
-      }, 5)
+      })
     }
 
     doRemove = (e, index) => {

--- a/examples/animations/app.js
+++ b/examples/animations/app.js
@@ -4,7 +4,12 @@
 	var createElement = Inferno.createElement;
   var InfernoAnimation = Inferno.Animation;
 
-  var AnimatedComponent = InfernoAnimation.AnimatedComponent;
+  var {
+    AnimatedComponent,
+    componentDidAppear,
+    componentWillDisappear
+  } = InfernoAnimation;
+  
   var {
     addClassName,
     removeClassName,
@@ -13,6 +18,11 @@
   } = InfernoAnimation.utils;
 
 	let renderCounter = 0;
+
+  const anim = {
+    onComponentDidAppear: componentDidAppear,
+    onComponentWillDisappear: componentWillDisappear
+  }
 
   class ListItem extends AnimatedComponent {
     render() {
@@ -26,6 +36,16 @@
     	renderCounter++;
       return createElement('section', { onClick: (e) => this.props.onClick(e, this.props.index)}, this.props.children);
     }
+  }
+
+  const FuncListItem = ({children, ...props}) => {
+    renderCounter++;
+    return createElement('li', { onClick: (e) => props.onClick(e, props.index)}, children);
+  }
+
+  const FuncSectionItem = ({children, ...props}) => {
+    renderCounter++;
+    return createElement('section', { onClick: (e) => props.onClick(e, props.index)}, children);
   }
 
 	class List extends Component {
@@ -66,9 +86,18 @@
       this.setState({ items: this.items });
 		}
 
+    renderItem = (item, i) => {
+      if (this.props.useFunctionalComponent) {
+        return createElement(FuncListItem, {key: item.key, index: i, animation: this.props.animation, ...anim, onClick: this.doRemove}, `${item.key + 1}bar`);
+      }
+      else {
+        return createElement(ListItem, {key: item.key, index: i, animation: this.props.animation, onClick: this.doRemove}, `${item.key + 1}bar`)
+      }
+    }
+
 		render() {
 			return createElement('div', null, [
-        createElement('ul', null, this.state.items.map((item, i) => createElement(ListItem, {key: item.key, index: i, animation: this.props.animation, onClick: this.doRemove}, `${item.key + 1}bar`))),
+        createElement('ul', null, this.state.items.map(this.renderItem)),
         createElement('h2', null, this.props.animation),
         createElement('p', null, this.props.description),
         createElement('button', { onClick: this.doAdd }, 'Add')
@@ -197,11 +226,21 @@
       });
     }
 
+    renderItem = (item, i) => {
+      if (this.props.useFunctionalComponent) {
+        return createElement(FuncSectionItem, {key: item.key, index: i, animation: this.props.animation, ...anim, onClick: this.doRemove}, `${item.key + 1}bar`)
+      }
+      else {
+        return createElement(SectionItem, {key: item.key, index: i, animation: this.props.animation, onClick: this.doRemove}, `${item.key + 1}bar`)
+      }
+
+    }
+
 		render() {
       // Mixing <section> and <span> instead of using <li> for all to trigger special code path in Inferno
 			return createElement('div', null, [
         createElement('article', null, this.state.items.map((item, i) => (item.isListItem
-          ? createElement(SectionItem, {key: item.key, index: i, animation: this.props.animation, onClick: this.doRemove}, `${item.key + 1}bar`)
+          ? this.renderItem(item, i)
           : createElement('span', {className: 'divider'})))),
         createElement('h2', null, 'Mixed list'),
         createElement('p', null, this.props.description),
@@ -329,9 +368,18 @@
       this.setState({ items: this.items });
 		}
 
+    renderItem = (item, i) => {
+      if (this.props.useFunctionalComponent) {
+        return createElement(FuncListItem, {key: item.key, index: i, animation: this.props.animation, ...anim, onClick: this.doRemove}, `${item.val}bar (${item.key})`);
+      }
+      else {
+        return createElement(ListItem, {key: item.key, index: i, animation: this.props.animation, onClick: this.doRemove}, `${item.val}bar (${item.key})`);
+      }
+    }
+
 		render() {
 			return createElement('div', null, [
-        createElement('ul', null, this.state.items.map((item, i) => createElement(ListItem, {key: item.key, index: i, animation: this.props.animation, onClick: this.doRemove}, `${item.val}bar (${item.key})`))),
+        createElement('ul', null, this.state.items.map(this.renderItem)),
         createElement('h2', null, 'Shuffle'),
         createElement('p', null, this.props.description),
         createElement('button', { onClick: this.doAdd }, 'Add'),
@@ -344,52 +392,6 @@
       ]);
 		}
 	}
-
-  class PatchingIssues extends Component {
-    constructor() {
-      super();
-      // set initial time:
-      this.state = {
-        items: [
-          this._getItem(1),
-          this._getItem(2),
-          this._getItem(3),
-          this._getItem(4)
-        ]
-      };
-      this.items = [];
-    }
-
-    _getItem(i) {
-      return {key: i, val: i}
-    }
-
-
-    doRemove = (e, index) => {
-      e.preventDefault();
-      var newItems = this.state.items.concat([]);
-      newItems.splice(index, 1)
-      this.setState({
-        items: newItems
-      })
-    }
-
-    useCase1 = (e) => {
-      // Setup the test
-      this.setState({
-
-      });
-    }
-
-    render() {
-      return createElement('div', null, [
-        createElement('ul', null, this.state.items.map((item, i) => createElement(ListItem, {key: item.key, index: i, animation: this.props.animation, onClick: this.doRemove}, `${item.val}bar (${item.key})`))),
-        createElement('h2', null, 'Patching bugs'),
-        createElement('p', null, this.props.description),
-        createElement('button', { onClick: this.useCase1 }, 'Use case 1')
-      ]);
-    }
-  }
 
   // https://stackoverflow.com/questions/2450954/how-to-randomize-shuffle-a-javascript-array
   var shuffle = (array) => {
@@ -455,9 +457,18 @@
       this.setState({ items: this.items });
     }
 
+    renderItem(item, i) {
+      if (this.props.useFunctionalComponent) {
+        return createElement(FuncListItem, {key: item.key, index: i, animation: this.props.animation, ...anim, onClick: this.doRemove}, `${item.val}bar (${item.key})`);
+      }
+      else {
+        return createElement(ListItem, {key: item.key, index: i, animation: this.props.animation, onClick: this.doRemove}, `${item.val}bar (${item.key})`);
+      }
+    }
+
 		render() {
 			return createElement('div', null, [
-        createElement('ul', null, this.state.items.map((item, i) => createElement(ListItem, {key: item.key, index: i, animation: this.props.animation, onClick: this.doRemove}, `${item.val}bar (${item.key})`))),
+        createElement('ul', null, this.state.items.map(this.renderItem)),
         createElement('h2', null, 'patchKeyedChildren'),
         createElement('p', null, this.props.description),
         createElement('button', { onClick: this.doAdd }, 'Add'),
@@ -471,25 +482,29 @@
 		var container_3 = document.querySelector('#App3');
 		var container_4 = document.querySelector('#App4');
     var container_5 = document.querySelector('#App5');
-    var container_6 = document.querySelector('#App6');
 
+    var useFunctionalComponent = location.search === '?functional'
 
     Inferno.render(createElement(List, {
+      useFunctionalComponent,
       animation: 'HeightAndFade',
       description: 'The children in this container animate opacity and height when added and removed. Click an item to remove it.',
     }), container_1);
 
     Inferno.render(createElement(List, {
+      useFunctionalComponent,
       animation: 'NoTranistionEvent',
       description: 'The children in this container have a broken animation. This is detected by inferno-animation and the animation callback is called immediately. Click an item to remove it.',
     }), container_2);
 
     Inferno.render(createElement(MixedList, {
+      useFunctionalComponent,
       animation: 'HeightAndFade',
       description: 'This container fades in and blocks the children from animating on first render. There is no animation on divider between elements. When you click [Remove] a random row and another random divder will be removed. Click an item to remove it (leaving the divider).',
     }), container_3);
 
     Inferno.render(createElement(ShuffleList, {
+      useFunctionalComponent,
       animation: 'HeightAndFade',
       description: 'This container will shuffle keys or items. Click an item to remove it.',
     }), container_4);
@@ -499,16 +514,11 @@
       e && e.preventDefault();
       //Inferno.render(createElement('div', null, createElement(RerenderList, {animation: 'HeightAndFade', items: 5})), container_5);
       Inferno.render(createElement(RerenderList, {
+        useFunctionalComponent,
         animation: 'HeightAndFade',
         items: 5,
         description: 'This container will be filled with 5 rows every time you click the button. Click an item to remove it.',
       }), container_5);
     });
-
-    // This currently doesn't do anything so hiding
-    // Inferno.render(createElement(PatchingIssues, {
-    //   animation: 'HeightAndFade',
-    //   description: 'This reproduce issues with patching and deferred removal of nodes.',
-    // }), container_6);
 	});
 })();

--- a/examples/animations/app.js
+++ b/examples/animations/app.js
@@ -204,6 +204,9 @@
       });
 
       // Remove random divider during animation
+      // NOTE! If the divider is the last element, it will cause everything to be removed,
+      // thus cutting the running animation short. This is expected behaviour because we don't
+      // check if the parent has an animating child. Opportunity for improvement.
       setTimeout(() => {
         var onlyDividers = this.state.items.filter((item) => !item.isListItem);
         var toDeleteIndex = parseInt(Math.round(Math.random() * (onlyDividers.length - 1)));

--- a/examples/animations/index.html
+++ b/examples/animations/index.html
@@ -10,7 +10,8 @@
     <script defer src="app.js" type="text/javascript"></script>
 </head>
   <body>
-    <h1>inferno-animation examples</h1>
+    <h1>inferno-animation examples
+        <small><a href="index.html">class components</a> | <a href="index.html?functional">functional components</a></small></h1>
     <div id="App1" class="App"></div>
     <div id="App2" class="App"></div>
     <div id="App3" class="App"></div>

--- a/packages/inferno-animation/__tests__/animatedComponent.spec.jsx
+++ b/packages/inferno-animation/__tests__/animatedComponent.spec.jsx
@@ -1,6 +1,6 @@
 import { render } from 'inferno';
 import { renderToString } from 'inferno-server';
-import { AnimatedComponent } from 'inferno-animation';
+import { AnimatedComponent, componentDidAppear, componentWillDisappear } from 'inferno-animation';
 
 describe('inferno-animation AnimatedComponent', () => {
   let container;
@@ -149,6 +149,164 @@ describe('inferno-animation AnimatedComponent', () => {
     }
 
     const outp = renderToString(<MyComponent>1</MyComponent>, container);
+    expect(outp).toBe('<div>1</div>');
+  });
+});
+
+describe('inferno-animation animated functional component', () => {
+  let container;
+
+  beforeEach(function () {
+    container = document.createElement('div');
+    document.body.appendChild(container);
+  });
+
+  function waitForAnimationAndContinue(condition, callback, arg1) {
+    if (container.textContent !== condition) {
+      return setTimeout(waitForAnimationAndContinue.bind(null, condition, callback, arg1), 10);
+    }
+
+    callback(arg1);
+  }
+
+  function afterEachClear(done) {
+    container.innerHTML = '';
+    document.body.removeChild(container);
+    done();
+  }
+
+  afterEach(function (done) {
+    render(null, container);
+    waitForAnimationAndContinue('', afterEachClear, done);
+  });
+
+  it('should render class component extending AnimatedComponent into DOM', () => {
+    const MyComponent = ({children}) => {
+      return <div>{children}</div>;
+    }
+
+    render(<MyComponent onComponentDidAppear={componentDidAppear} onComponentWillDisappear={componentWillDisappear}>1</MyComponent>, container);
+    expect(container.textContent).toBe('1');
+  });
+
+  it('should remove class component extending AnimatedComponent from DOM', (done) => {
+    const My = ({children}) => {
+      return <div>{children}</div>;
+    }
+
+    const anim = {
+      onComponentDidAppear: componentDidAppear,
+      onComponentWillDisappear: componentWillDisappear
+    }
+
+    render(
+      <div>
+        <My key="#1" {...anim}>1</My>
+        <My key="#2" {...anim}>2</My>
+        <My key="#3" {...anim}>3</My>
+      </div>,
+      container
+    );
+    expect(container.textContent).toBe('123');
+
+    render(
+      <div>
+        <My key="#1" {...anim}>1</My>
+        <My key="#3" {...anim}>3</My>
+      </div>,
+      container
+    );
+
+    /**
+     * The reason for recursively calling checkRenderComplete_XXX instead of
+     * using a simpler setTimeout is due to a couple of async calls during the animations
+     * hooks of AnimatedComponent. These can cause a setTimeout in the test to
+     * trigger prior to the animation callbacks and thus remove operations haven't yet
+     * been completed. As long as the render operation eventually completes correctly,
+     * the test should be considered successful.
+     */
+
+    waitForAnimationAndContinue('13', function () {
+      render(
+        <div>
+          <My key="#1" {...anim}>1</My>
+          <My key="#4" {...anim}>4</My>
+        </div>,
+        container
+      );
+
+      waitForAnimationAndContinue('14', function () {
+        done();
+      });
+    });
+  });
+
+  it('should move class component extending AnimatedComponent from DOM', (done) => {
+    const My = ({children}) => {
+      return <div>{children}</div>;
+    }
+
+    const anim = {
+      onComponentDidAppear: componentDidAppear,
+      onComponentWillDisappear: componentWillDisappear
+    }
+
+    render(
+      <div>
+        <My key="#1" {...anim}>1</My>
+        <My key="#2" {...anim}>2</My>
+        <My key="#3" {...anim}>3</My>
+      </div>,
+      container
+    );
+    expect(container.textContent).toBe('123');
+
+    render(
+      <div>
+        <My key="#1" {...anim}>1</My>
+        <My key="#3" {...anim}>3</My>
+        <My key="#2" {...anim}>2</My>
+      </div>,
+      container
+    );
+
+    /**
+     * The reason for recursively calling checkRenderComplete_XXX instead of
+     * using a simpler setTimeout is due to a couple of async calls during the animations
+     * hooks of AnimatedComponent. These can cause a setTimeout in the test to
+     * trigger prior to the animation callbacks and thus remove operations haven't yet
+     * been completed. As long as the render operation eventually completes correctly,
+     * the test should be considered successful.
+     */
+    // Disappear animations complete async
+
+    waitForAnimationAndContinue('132', function () {
+      render(
+        <div>
+          <My key="#4" {...anim}>4</My>
+          <My key="#1" {...anim}>1</My>
+        </div>,
+        container
+      );
+
+      waitForAnimationAndContinue('41', function () {
+        render(null, container);
+        done();
+      });
+    });
+  });
+
+  it('should render class component extending AnimatedComponent to a string', () => {
+    const MyComponent = ({children}) => {
+      return <div>{children}</div>;
+    }
+
+    const anim = {
+      onComponentDidAppear: componentDidAppear,
+      onComponentWillDisappear: componentWillDisappear
+    }
+
+    const outp = renderToString(<MyComponent {...anim}>1</MyComponent>, container);
     expect(outp).toBe('<div>1</div>');
   });
 });

--- a/packages/inferno-animation/src/AnimatedComponent.ts
+++ b/packages/inferno-animation/src/AnimatedComponent.ts
@@ -1,98 +1,17 @@
 import { Component, InfernoNode } from 'inferno';
-import { addClassName, clearDimensions, forceReflow, getDimensions, registerTransitionListener, removeClassName, setDimensions } from './utils';
-import { isNullOrUndef } from 'inferno-shared';
-
-type animationClass = {
-  active: string;
-  end: string;
-  start: string;
-};
+import { componentDidAppear, componentWillDisappear, AnimationClass } from './animations';
 
 type AnimationProp = {
-  animation?: string | animationClass;
+  animation?: string | AnimationClass;
   children?: InfernoNode;
 };
 
-function getAnimationClass(animationProp: animationClass | string | undefined | null, prefix: string): animationClass {
-  let animCls: animationClass;
-
-  if (!isNullOrUndef(animationProp) && typeof animationProp === 'object') {
-    animCls = animationProp;
-  } else {
-    const animationName = animationProp || 'inferno-animation';
-    animCls = {
-      active: `${animationName}${prefix}-active`,
-      end: `${animationName}${prefix}-end`,
-      start: `${animationName}${prefix}`
-    };
-  }
-
-  return animCls;
-}
-
 export class AnimatedComponent<P = {}, S = {}> extends Component<AnimationProp & P, S> {
-  public componentDidAppear(dom) {
-    const { start, end, active } = getAnimationClass(this.props.animation, '-enter');
-
-    // 1. Get height and set start of animation
-    const { width, height } = getDimensions(dom);
-    addClassName(dom, start);
-    forceReflow();
-
-    // 2. Activate transition
-    addClassName(dom, active);
-
-    // 3. Set an animation listener, code at end
-    // Needs to be done after activating so timeout is calculated correctly
-    registerTransitionListener(
-      [dom],
-      function () {
-        // *** Cleanup ***
-        // 5. Remove the element
-        clearDimensions(dom);
-        removeClassName(dom, active);
-        removeClassName(dom, end);
-
-        // 6. Call callback to allow stuff to happen
-        // Not currently used but this is where one could
-        // add a call to something like this.didAppearDone
-      }
-    );
-
-    // 4. Activate target state
-    requestAnimationFrame(() => {
-      setDimensions(dom, width, height);
-      removeClassName(dom, start);
-      addClassName(dom, end);
-    });
+  public componentDidAppear(dom: HTMLElement) {
+    componentDidAppear(dom, this.props);
   }
 
-  public componentWillDisappear(dom, callback) {
-    const { start, end, active } = getAnimationClass(this.props.animation, '-leave');
-
-    // 1. Get dimensions and set animation start state
-    const { width, height } = getDimensions(dom);
-    setDimensions(dom, width, height);
-    addClassName(dom, start);
-
-    // 2. Activate transitions
-    addClassName(dom, active);
-
-    // 3. Set an animation listener, code at end
-    // Needs to be done after activating so timeout is calculated correctly
-    registerTransitionListener(
-      [dom],
-      function () {
-        // *** Cleanup not needed since node is removed ***
-        callback();
-      }
-    );
-
-    // 4. Activate target state
-    requestAnimationFrame(() => {
-      addClassName(dom, end);
-      removeClassName(dom, start);
-      clearDimensions(dom);
-    });
+  public componentWillDisappear(dom: HTMLElement, callback: Function) {
+    componentWillDisappear(dom, this.props, callback);
   }
 }

--- a/packages/inferno-animation/src/AnimatedComponent.ts
+++ b/packages/inferno-animation/src/AnimatedComponent.ts
@@ -45,7 +45,7 @@ export class AnimatedComponent<P = {}, S = {}> extends Component<AnimationProp &
     // 3. Set an animation listener, code at end
     // Needs to be done after activating so timeout is calculated correctly
     registerTransitionListener(
-      [dom, dom.children[0]],
+      [dom],
       function () {
         // *** Cleanup ***
         // 5. Remove the element
@@ -56,8 +56,7 @@ export class AnimatedComponent<P = {}, S = {}> extends Component<AnimationProp &
         // 6. Call callback to allow stuff to happen
         // Not currently used but this is where one could
         // add a call to something like this.didAppearDone
-      },
-      false
+      }
     );
 
     // 4. Activate target state
@@ -82,12 +81,11 @@ export class AnimatedComponent<P = {}, S = {}> extends Component<AnimationProp &
     // 3. Set an animation listener, code at end
     // Needs to be done after activating so timeout is calculated correctly
     registerTransitionListener(
-      dom,
+      [dom],
       function () {
         // *** Cleanup not needed since node is removed ***
         callback();
-      },
-      false
+      }
     );
 
     // 4. Activate target state

--- a/packages/inferno-animation/src/animations.ts
+++ b/packages/inferno-animation/src/animations.ts
@@ -1,0 +1,90 @@
+import { addClassName, clearDimensions, forceReflow, getDimensions, registerTransitionListener, removeClassName, setDimensions } from './utils';
+import { isNullOrUndef } from 'inferno-shared';
+
+export type AnimationClass = {
+  active: string;
+  end: string;
+  start: string;
+};
+
+function getAnimationClass(animationProp: AnimationClass | string | undefined | null, prefix: string): AnimationClass {
+  let animCls: AnimationClass;
+
+  if (!isNullOrUndef(animationProp) && typeof animationProp === 'object') {
+    animCls = animationProp;
+  } else {
+    const animationName = animationProp || 'inferno-animation';
+    animCls = {
+      active: `${animationName}${prefix}-active`,
+      end: `${animationName}${prefix}-end`,
+      start: `${animationName}${prefix}`
+    };
+  }
+
+  return animCls;
+}
+
+export function componentDidAppear(dom: HTMLElement, props) {
+  const { start, end, active } = getAnimationClass(props.animation, '-enter');
+
+  // 1. Get height and set start of animation
+  const { width, height } = getDimensions(dom);
+  addClassName(dom, start);
+  forceReflow();
+
+  // 2. Activate transition
+  addClassName(dom, active);
+
+  // 3. Set an animation listener, code at end
+  // Needs to be done after activating so timeout is calculated correctly
+  registerTransitionListener(
+    [dom],
+    function () {
+      // *** Cleanup ***
+      // 5. Remove the element
+      clearDimensions(dom);
+      removeClassName(dom, active);
+      removeClassName(dom, end);
+
+      // 6. Call callback to allow stuff to happen
+      // Not currently used but this is where one could
+      // add a call to something like this.didAppearDone
+    }
+  );
+
+  // 4. Activate target state
+  requestAnimationFrame(() => {
+    setDimensions(dom, width, height);
+    removeClassName(dom, start);
+    addClassName(dom, end);
+  });
+}
+
+export function componentWillDisappear(dom: HTMLElement, props, callback: Function) {
+  const { start, end, active } = getAnimationClass(props.animation, '-leave');
+
+  // 1. Get dimensions and set animation start state
+  const { width, height } = getDimensions(dom);
+  setDimensions(dom, width, height);
+  addClassName(dom, start);
+
+  // 2. Activate transitions
+  addClassName(dom, active);
+
+  // 3. Set an animation listener, code at end
+  // Needs to be done after activating so timeout is calculated correctly
+  registerTransitionListener(
+    [dom],
+    function () {
+      // *** Cleanup not needed since node is removed ***
+      callback();
+    }
+  );
+
+  // 4. Activate target state
+  requestAnimationFrame(() => {
+    addClassName(dom, end);
+    removeClassName(dom, start);
+    clearDimensions(dom);
+  });
+}

--- a/packages/inferno-animation/src/index.ts
+++ b/packages/inferno-animation/src/index.ts
@@ -1,7 +1,7 @@
 export { AnimatedComponent } from './AnimatedComponent';
+export { componentDidAppear, componentWillDisappear, AnimationClass } from './animations';
 
 import { addClassName, clearDimensions, forceReflow, getDimensions, registerTransitionListener, removeClassName, setDimensions, setDisplay } from './utils';
-
 export const utils = {
   addClassName,
   clearDimensions,

--- a/packages/inferno-animation/src/utils.ts
+++ b/packages/inferno-animation/src/utils.ts
@@ -178,12 +178,6 @@ function setAnimationTimeout(onTransitionEnd, rootNode, maxDuration) {
  * will be animations that fail to complete before the timeout is triggered.
  */
 export function registerTransitionListener(nodes: HTMLElement[], callback: Function, noTimeout: boolean = false) {
-  if (!Array.isArray(nodes)) {
-    nodes = [nodes];
-  } else {
-    // Make sure we don't have undefined nodes (happens when an animated el doesn't have children)
-    nodes = nodes.filter((node) => node);
-  }
   const rootNode = nodes[0];
 
   /**
@@ -204,7 +198,8 @@ export function registerTransitionListener(nodes: HTMLElement[], callback: Funct
       // Make sure it isn't a child that is triggering the event
       let goAhead = false;
       for (let i = 0; i < nodes.length; i++) {
-        if (event.target === nodes[i]) {
+        // Note: Check for undefined nodes (happens when an animated el doesn't have children)
+        if (nodes[i] !== undefined && event.target === nodes[i]) {
           goAhead = true;
           break;
         }

--- a/packages/inferno-animation/src/utils.ts
+++ b/packages/inferno-animation/src/utils.ts
@@ -188,7 +188,7 @@ export function registerTransitionListener(nodes: HTMLElement[], callback: Funct
   let nrofTransitionsLeft = transitionDuration.nrofTransitions;
   let done = false;
 
-  function onTransitionEnd(event) {
+  const onTransitionEnd = (event) => {
     // Make sure this is an actual event
     if (!event || done) {
       return;

--- a/packages/inferno-animation/src/utils.ts
+++ b/packages/inferno-animation/src/utils.ts
@@ -160,7 +160,7 @@ const transitionEndName: string = (function () {
   }
 })();
 
-function debugAnimations(onTransitionEnd, rootNode, maxDuration) {
+function setAnimationTimeout(onTransitionEnd, rootNode, maxDuration) {
   if (rootNode.nodeName === 'IMG' && !(rootNode as any).complete) {
     // Image animations should wait for loaded until the timeout is started, otherwise animation will be cut short
     // due to loading delay
@@ -234,7 +234,7 @@ export function registerTransitionListener(nodes: HTMLElement[], callback: Funct
   // Fallback if transitionend fails
   // This is disabled during debug so we can set breakpoints
   if (!(process.env.NODE_ENV !== 'production' && isDebugAnimationsSet()) && !noTimeout) {
-    debugAnimations(onTransitionEnd, rootNode, maxDuration);
+    setAnimationTimeout(onTransitionEnd, rootNode, maxDuration);
   }
 }
 

--- a/packages/inferno-animation/src/utils.ts
+++ b/packages/inferno-animation/src/utils.ts
@@ -1,4 +1,4 @@
-import { isFunction, isString } from 'inferno-shared';
+import { isFunction, isString, warning } from 'inferno-shared';
 
 declare global {
   // Setting `window.__DEBUG_ANIMATIONS__ = true;` disables animation timeouts
@@ -176,8 +176,11 @@ function setAnimationTimeout(onTransitionEnd, rootNode, maxDuration) {
  * You need to pass the root element and ALL animated children that have transitions,
  * if there are any,  so the timeout is set to the longest duration. Otherwise there
  * will be animations that fail to complete before the timeout is triggered.
+ * 
+ * @param nodes a list of nodes that have transitions that are part of this animation
+ * @param callback callback when all transitions of participating nodes are completed
  */
-export function registerTransitionListener(nodes: HTMLElement[], callback: Function, noTimeout: boolean = false) {
+export function registerTransitionListener(nodes: HTMLElement[], callback: Function) {
   const rootNode = nodes[0];
 
   /**
@@ -228,8 +231,12 @@ export function registerTransitionListener(nodes: HTMLElement[], callback: Funct
 
   // Fallback if transitionend fails
   // This is disabled during debug so we can set breakpoints
-  if (!(process.env.NODE_ENV !== 'production' && isDebugAnimationsSet()) && !noTimeout) {
+  // WARNING: If the callback isn't called, the DOM nodes won't be removed
+  if (!(process.env.NODE_ENV !== 'production' && isDebugAnimationsSet())) {
     setAnimationTimeout(onTransitionEnd, rootNode, maxDuration);
+  }
+  else if (process.env.NODE_ENV !== 'production') {
+    warning('You are in animation debugging mode and fallback timeouts aren\'t set. DOM nodes could be left behind.')
   }
 }
 

--- a/packages/inferno-create-element/src/index.ts
+++ b/packages/inferno-create-element/src/index.ts
@@ -13,14 +13,14 @@ import { isInvalid, isNullOrUndef, isString, isUndefined } from 'inferno-shared'
 import { ChildFlags, VNodeFlags } from 'inferno-vnode-flags';
 
 const componentHooks = {
+  onComponentDidAppear: 1,
   onComponentDidMount: 1,
   onComponentDidUpdate: 1,
   onComponentShouldUpdate: 1,
+  onComponentWillDisappear: 1,
   onComponentWillMount: 1,
   onComponentWillUnmount: 1,
-  onComponentWillUpdate: 1,
-  onComponentDidAppear: 1,
-  onComponentWillDisappear: 1
+  onComponentWillUpdate: 1
 };
 
 /**

--- a/packages/inferno-create-element/src/index.ts
+++ b/packages/inferno-create-element/src/index.ts
@@ -18,7 +18,9 @@ const componentHooks = {
   onComponentShouldUpdate: 1,
   onComponentWillMount: 1,
   onComponentWillUnmount: 1,
-  onComponentWillUpdate: 1
+  onComponentWillUpdate: 1,
+  onComponentDidAppear: 1,
+  onComponentWillDisappear: 1
 };
 
 /**

--- a/packages/inferno-hydrate/src/index.ts
+++ b/packages/inferno-hydrate/src/index.ts
@@ -63,7 +63,7 @@ function hydrateComponent(
     const input = _HI(renderFunctionalComponent(vNode, context));
     currentNode = hydrateVNode(input, parentDOM, dom, context, isSVG, lifecycle, animations);
     vNode.children = input;
-    _MFCC(vNode, lifecycle);
+    _MFCC(vNode, lifecycle, animations);
   }
 
   return currentNode;

--- a/packages/inferno-server/__tests__/animationHooks.spec.server.jsx
+++ b/packages/inferno-server/__tests__/animationHooks.spec.server.jsx
@@ -49,4 +49,60 @@ describe('SSR Creation (JSX)', () => {
       done();
     }, 10);
   });
+
+  it('should not call "onComponentDidAppear" when component is rendered with renderToStaticMarkup', (done) => {
+    const spyer = jasmine.createSpy();
+
+    const MyComp = () => {
+      return <div />;
+    }
+
+    const onComponentDidAppear = (dom) => {
+      spyer('didAppear');
+      expect(dom instanceof HTMLDivElement).toEqual(true);
+    }
+
+    class App extends Component {
+      render() {
+        return <MyComp onComponentDidAppear={onComponentDidAppear} />;
+      }
+    }
+
+    const outp = renderToStaticMarkup(<App />);
+
+    // Doing this async to be sure
+    setTimeout(() => {
+      expect(spyer).toHaveBeenCalledTimes(0);
+      expect(outp).toEqual('<div></div>');
+      done();
+    }, 10);
+  });
+
+  it('should not call "onComponentDidAppear" when component is rendered with renderToString', (done) => {
+    const spyer = jasmine.createSpy();
+
+    const MyComp = () => {
+      return <div />;
+    }
+
+    const onComponentDidAppear = (dom) => {
+      spyer('didAppear');
+      expect(dom instanceof HTMLDivElement).toEqual(true);
+    }
+
+    class App extends Component {
+      render() {
+        return <MyComp onComponentDidAppear={onComponentDidAppear} />;
+      }
+    }
+
+    const outp = renderToString(<App />);
+
+    // Doing this async to be sure
+    setTimeout(() => {
+      expect(spyer).toHaveBeenCalledTimes(0);
+      expect(outp).toEqual('<div></div>');
+      done();
+    }, 10);
+  });
 });

--- a/packages/inferno/__tests__/animationHooksFunc.spec.jsx
+++ b/packages/inferno/__tests__/animationHooksFunc.spec.jsx
@@ -1,0 +1,1106 @@
+import { Component, render } from 'inferno';
+import { createElement } from 'inferno-create-element';
+
+describe('animation hooks', () => {
+  let container;
+
+  beforeEach(function () {
+    container = document.createElement('div');
+    document.body.appendChild(container);
+  });
+
+  afterEach(function () {
+    render(null, container);
+    container.innerHTML = '';
+    document.body.removeChild(container);
+  });
+
+  it('should call "onComponentDidAppear" when component has been inserted into DOM', () => {
+    const spyer = jasmine.createSpy();
+
+    const Animated = () => {
+      return <div />;
+    }
+
+    const onComponentDidAppear = (dom, props) => {
+      spyer('didAppear');
+      expect(dom instanceof HTMLDivElement).toEqual(true);
+      expect(typeof props === 'object').toEqual(true);
+    }
+
+    class App extends Component {
+      componentDidMount() {
+        spyer('didMount');
+      }
+      render() {
+        return <Animated onComponentDidAppear={onComponentDidAppear} />;
+      }
+    }
+
+    render(<App />, container);
+
+    expect(spyer).toHaveBeenCalledTimes(2);
+    expect(spyer.calls.argsFor(0)).toEqual(['didMount']);
+    expect(spyer.calls.argsFor(1)).toEqual(['didAppear']);
+  });
+
+  it('should only call parent "onComponentDidAppear" when component tree has been inserted into DOM', () => {
+    const spyer = jasmine.createSpy();
+
+    const Child = () => {
+      return <div />;
+    }
+    
+    const childOnComponentDidAppear = (dom, props) => {
+      spyer('no-op');
+      expect(dom instanceof HTMLDivElement).toEqual(true);
+    }
+
+    const Parent = () => {
+      return <Child onComponentDidAppear={childOnComponentDidAppear} />;
+    }
+    
+    const parentOnComponentDidAppear = (dom, props) => {
+      spyer('didAppear');
+      expect(dom instanceof HTMLDivElement).toEqual(true);
+    }
+
+    class App extends Component {
+      componentDidMount() {
+        spyer('didMount');
+      }
+      render() {
+        return (
+          <div>
+            <Parent onComponentDidAppear={parentOnComponentDidAppear} />
+          </div>
+        );
+      }
+    }
+
+    render(<App />, container);
+
+    expect(spyer).toHaveBeenCalledTimes(2);
+    expect(spyer.calls.argsFor(0)).toEqual(['didMount']);
+    expect(spyer.calls.argsFor(1)).toEqual(['didAppear']);
+  });
+
+  it('should only call "componentDidAppear" when child component has been inserted into DOM', (done) => {
+    const spyer = jasmine.createSpy();
+
+    const Child = (props) => {
+      return <div>{props.children}</div>;
+    }
+
+    const childOnComponentDidMount = () => {
+      spyer('childDidMount');
+    }
+
+    const childOnComponentDidAppear = () => {
+      spyer('childDidAppear');
+    }
+
+    class App extends Component {
+      constructor() {
+        super(...arguments);
+        this.state = {
+          items: [1]
+        };
+      }
+
+      componentDidMount() {
+        spyer('didMount');
+        setTimeout(() => {
+          this.setState({
+            items: [1, 2]
+          });
+          // Make sure inferno is done and then check the results
+          setTimeout(finished, 5);
+        }, 5);
+      }
+
+      render() {
+        return (
+          <div>
+            {this.state.items.map((i) => (
+              <Child key={i} onComponentDidAppear={childOnComponentDidAppear} onComponentDidMount={childOnComponentDidMount}>{i}</Child>
+            ))}
+          </div>
+        );
+      }
+    }
+
+    render(<App />, container);
+
+    const finished = () => {
+      expect(spyer).toHaveBeenCalledTimes(5);
+      expect(spyer.calls.argsFor(0)).toEqual(['childDidMount']);
+      expect(spyer.calls.argsFor(1)).toEqual(['didMount']);
+      expect(spyer.calls.argsFor(2)).toEqual(['childDidAppear']);
+      expect(spyer.calls.argsFor(3)).toEqual(['childDidMount']);
+      expect(spyer.calls.argsFor(4)).toEqual(['childDidAppear']);
+      expect(container.innerHTML).toEqual('<div><div>1</div><div>2</div></div>');
+      done();
+    };
+  });
+
+  it('should call all "componentDidAppear" when multiple siblings have been inserted into DOM', () => {
+    const spyer = jasmine.createSpy();
+
+    const Child = () => {
+      return <div />;
+    }
+
+    const onComponentDidAppear = (dom, props) => {
+      spyer('childDidAppear');
+      expect(dom instanceof HTMLDivElement).toEqual(true);
+    }
+
+    class App extends Component {
+      componentDidMount() {
+        spyer('didMount');
+      }
+      render() {
+        return (
+          <div>
+            <Child onComponentDidAppear={onComponentDidAppear} />
+            <Child onComponentDidAppear={onComponentDidAppear} />
+            <Child onComponentDidAppear={onComponentDidAppear} />
+            <Child onComponentDidAppear={onComponentDidAppear} />
+          </div>
+        );
+      }
+    }
+
+    render(<App />, container);
+
+    expect(spyer).toHaveBeenCalledTimes(5);
+    expect(spyer.calls.argsFor(0)).toEqual(['didMount']);
+    expect(spyer.calls.argsFor(1)).toEqual(['childDidAppear']);
+    expect(spyer.calls.argsFor(2)).toEqual(['childDidAppear']);
+    expect(spyer.calls.argsFor(3)).toEqual(['childDidAppear']);
+    expect(spyer.calls.argsFor(4)).toEqual(['childDidAppear']);
+  });
+
+  it('should call "componentWillDisappear" when component is about to be removed from DOM', () => {
+    const spyer = jasmine.createSpy();
+    const App = () => {
+      return <div />;
+    }
+    
+    const onComponentWillDisappear = (dom, props, callback) => {
+      spyer('willDisappear');
+      expect(dom instanceof HTMLDivElement).toEqual(true);
+      expect(callback instanceof Function).toEqual(true);
+      expect(typeof props === 'object').toEqual(true);
+      callback();
+    }
+
+    const onComponentDidMount = () => {
+      spyer('didMount');
+    }
+
+    render(<App onComponentWillDisappear={onComponentWillDisappear} onComponentDidMount={onComponentDidMount} />, container);
+
+    render(null, container);
+
+    expect(spyer).toHaveBeenCalledTimes(2);
+    expect(spyer.calls.argsFor(0)).toEqual(['didMount']);
+    expect(spyer.calls.argsFor(1)).toEqual(['willDisappear']);
+  });
+
+  it('should handle async callbacks from "componentWillDisappear"', (done) => {
+    const spyer = jasmine.createSpy();
+
+    const App = () => {
+      return <div />;
+    }
+    
+    const onComponentWillDisappear = (dom, props, callback) => {
+      spyer('willDisappear');
+      expect(dom instanceof HTMLDivElement).toEqual(true);
+      expect(callback instanceof Function).toEqual(true);
+      setTimeout(() => {
+        callback();
+        setTimeout(() => didFinish(), 10);
+      }, 10);
+    }
+
+    const onComponentDidMount = () => {
+      spyer('didMount');
+    }
+
+    render(<App onComponentWillDisappear={onComponentWillDisappear} onComponentDidMount={onComponentDidMount} />, container);
+
+    render(null, container);
+
+    function didFinish() {
+      expect(spyer).toHaveBeenCalledTimes(2);
+      expect(spyer.calls.argsFor(0)).toEqual(['didMount']);
+      expect(spyer.calls.argsFor(1)).toEqual(['willDisappear']);
+      done();
+    }
+  });
+
+  it('should handle async callbacks "componentWillDisappear" when removing the two last elements in list', (done) => {
+    /**
+     * This test is hard to get to consistently fail. It should trigger
+     * clearDOM from last animation callback prior to deferComponentClassRemoval
+     * of at least one item. But it does work as expected now
+     * Change
+     * clearVNodeDOM(vNode, parentDOM, true);
+     * to
+     * clearVNodeDOM(vNode, parentDOM, false);
+     * in
+     * function deferComponentClassRemoval
+     * to force failure
+     */
+    const spyer = jasmine.createSpy();
+
+    const Item = () => {
+      return <div />;
+    }
+    
+    const getOnComponentWillDisappear = (index) => {
+      return (dom, props, callback) => {
+        spyer('willDisappear ' + index);
+
+        let timeout = 10;
+        if (index === 0) {
+          timeout = 0;
+        }
+        setTimeout(() => {
+          callback();
+        }, timeout);
+      }
+    }
+
+    const onComponentDidMount = () => {
+      spyer('didMount');
+    }
+
+
+    class App extends Component {
+      state = {
+        items: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19]
+      };
+
+      render() {
+        if (this.state.items.length > 0) {
+          setTimeout(() => {
+            const items = this.state.items;
+            items.pop();
+            this.setState({ items });
+          });
+        }
+
+        if (this.state.items.length === 0) {
+          return <div />;
+        }
+
+        return (
+          <div>
+            {this.state.items.map((i) => (
+              <Item key={i} onComponentWillDisappear={getOnComponentWillDisappear(i)} onComponentDidMount={onComponentDidMount} />
+            ))}
+          </div>
+        );
+      }
+    }
+
+    render(<App />, container);
+
+    var checkRenderComplete_ONE = () => {
+      if (container.innerHTML !== '<div></div>') {
+        return setTimeout(checkRenderComplete_ONE, 100);
+      }
+      expect(spyer).toHaveBeenCalledTimes(40);
+      expect(spyer.calls.argsFor(0)).toEqual(['didMount']);
+      expect(spyer.calls.argsFor(19)).toEqual(['didMount']);
+      expect(spyer.calls.argsFor(20)).toEqual(['willDisappear 19']);
+      expect(spyer.calls.argsFor(39)).toEqual(['willDisappear 0']);
+      done();
+    };
+    checkRenderComplete_ONE();
+  });
+
+  it('should handle async callbacks from "componentWillDisappear" and mounting components with "componentDidAppear"', (done) => {
+    const spyer = jasmine.createSpy();
+    // Always call the componentWillDisappear callback after last render
+    let lastRenderDone = false;
+    let callMeAfterLastRender;
+
+    const App = () => {
+      return <div />;
+    }
+    
+    const onComponentDidAppear = (dom, props) => {
+      spyer('didAppear');
+      expect(dom instanceof HTMLDivElement).toEqual(true);
+    }
+    
+    const getOnComponentWillDisappear = (forceDone) => (dom, props, callback) => {
+      spyer('willDisappear');
+      expect(dom instanceof HTMLDivElement).toEqual(true);
+      expect(callback instanceof Function).toEqual(true);
+
+      if (forceDone) {
+        callback();
+      } else {
+        setTimeout(() => {
+          callMeAfterLastRender = () => {
+            callback();
+            setTimeout(() => didFinish(), 10);
+          };
+          lastRenderDone && callMeAfterLastRender();
+        }, 10);
+      }
+    }
+      
+    const onComponentDidMount = () => {
+      spyer('didMount');
+    }
+
+    render(<App onComponentDidAppear={onComponentDidAppear} onComponentDidMount={onComponentDidMount} onComponentWillDisappear={getOnComponentWillDisappear(false)} />, container);
+    render(null, container);
+    // forceDone completes the willDissapear hook immediately
+    render(<App  onComponentDidAppear={onComponentDidAppear} onComponentDidMount={onComponentDidMount} onComponentWillDisappear={getOnComponentWillDisappear(true)} />, container);
+
+    expect(container.innerHTML).toBe('<div></div><div></div>');
+
+    lastRenderDone = true;
+    callMeAfterLastRender && callMeAfterLastRender();
+
+    function didFinish() {
+      expect(spyer).toHaveBeenCalledTimes(5);
+      expect(spyer.calls.argsFor(0)).toEqual(['didMount']);
+      expect(spyer.calls.argsFor(1)).toEqual(['didAppear']);
+      expect(spyer.calls.argsFor(2)).toEqual(['willDisappear']);
+      expect(spyer.calls.argsFor(3)).toEqual(['didMount']);
+      expect(spyer.calls.argsFor(4)).toEqual(['didAppear']);
+      expect(container.innerHTML).toBe('<div></div>');
+
+      render(null, container);
+      expect(container.innerHTML).toBe('');
+      done();
+    }
+  });
+
+  it('should handle async callbacks even when parent is removed during animation', (done) => {
+    const spyer = jasmine.createSpy();
+    const App = () => {
+      return <div />;
+    }
+
+    const onComponentWillDisappear = (dom, props, callback) => {
+      spyer('willDisappear');
+      expect(dom instanceof HTMLDivElement).toEqual(true);
+      expect(callback instanceof Function).toEqual(true);
+      setTimeout(() => {
+        callback();
+      }, 10);
+    }
+
+    const onComponentDidMount = () => {
+      spyer('didMount');
+    }
+
+    render(
+      <div>
+        <App onComponentDidMount={onComponentDidMount} onComponentWillDisappear={onComponentWillDisappear} />
+        <App onComponentDidMount={onComponentDidMount} onComponentWillDisappear={onComponentWillDisappear} />
+      </div>,
+      container
+    );
+    render(
+      <div>
+        <App onComponentDidMount={onComponentDidMount} onComponentWillDisappear={onComponentWillDisappear} />
+      </div>,
+      container
+    );
+    render(null, container);
+
+    expect(container.innerHTML).not.toEqual('');
+    // Wait for all async operations to finish
+    var checkRenderComplete_ONE = () => {
+      if (container.innerHTML !== '') {
+        return setTimeout(checkRenderComplete_ONE, 10);
+      }
+      expect(spyer).toHaveBeenCalledTimes(6);
+      expect(spyer.calls.argsFor(0)).toEqual(['didMount']);
+      expect(spyer.calls.argsFor(1)).toEqual(['didMount']);
+      expect(spyer.calls.argsFor(2)).toEqual(['willDisappear']);
+      expect(spyer.calls.argsFor(3)).toEqual(['willDisappear']);
+      expect(spyer.calls.argsFor(4)).toEqual(['didMount']);
+      expect(spyer.calls.argsFor(5)).toEqual(['willDisappear']);
+      done();
+    };
+    checkRenderComplete_ONE();
+  });
+
+  it('should call "willMove" when component is about to be moved to another part of DOM', () => {});
+
+  const template = function (child) {
+    return createElement('div', null, child);
+  };
+
+  it('should add all nodes', () => {
+    const spyer = jasmine.createSpy();
+
+    render(template(generateKeyNodes([], spyer)), container);
+    render(template(generateKeyNodes(['#0', '#1', '#2', '#3'], spyer)), container);
+    expect(container.textContent).toBe('#0#1#2#3');
+    expect(container.firstChild.childNodes.length).toBe(4);
+    //expect(spyer).toHaveBeenCalledTimes(4);
+
+    render(null, container);
+    expect(container.innerHTML).toBe('');
+    //expect(spyer).toHaveBeenCalledTimes(8);
+  });
+
+  it('should size up', () => {
+    const spyer = jasmine.createSpy();
+    render(template(generateKeyNodes(['#0', '#1'], spyer)), container);
+    render(template(generateKeyNodes(['#0', '#1', '#2', '#3'], spyer)), container);
+    expect(container.textContent).toBe('#0#1#2#3');
+    expect(container.firstChild.childNodes.length).toBe(4);
+    //expect(spyer).toHaveBeenCalledTimes(4);
+
+    render(null, container);
+    expect(container.innerHTML).toBe('');
+    // expect(spyer).toHaveBeenCalledTimes(8);
+  });
+
+  it('should do smiple size down', () => {
+    const spyer = jasmine.createSpy();
+    render(template(generateKeyNodes(['#0', '#1', '#2'], spyer)), container);
+    render(template(generateKeyNodes(['#0', '#2'], spyer)), container);
+    expect(container.textContent).toBe('#0#2');
+    expect(container.firstChild.childNodes.length).toBe(2);
+    //expect(spyer).toHaveBeenCalledTimes(4);
+
+    render(null, container);
+    expect(container.innerHTML).toBe('');
+    // expect(spyer).toHaveBeenCalledTimes(8);
+  });
+
+  it('should size down', () => {
+    const spyer = jasmine.createSpy();
+    render(template(generateKeyNodes(['#0', '#1', '#2', '#3'], spyer)), container);
+    render(template(generateKeyNodes(['#0', '#1'], spyer)), container);
+    // expect(spyer).toHaveBeenCalledTimes(2);
+    expect(container.textContent).toBe('#0#1');
+    expect(container.firstChild.childNodes.length).toBe(2);
+
+    render(template(generateKeyNodes(['#0', '#1', '#2', '#3'], spyer)), container);
+    render(template(generateKeyNodes(['#0', '#1'], spyer)), container);
+
+    //expect(spyer).toHaveBeenCalledTimes(10);
+    expect(container.textContent).toBe('#0#1');
+    expect(container.firstChild.childNodes.length).toBe(2);
+
+    render(null, container);
+    expect(container.innerHTML).toBe('');
+    //expect(spyer).toHaveBeenCalledTimes(12);
+  });
+
+  it('should handle multiple removes of siblings combined with adds', () => {
+    const spyer = jasmine.createSpy();
+    render(template(generateKeyNodes(['#0', '#1', '#2', '#3', '#4', '#5'], spyer)), container);
+    render(template(generateKeyNodes(['#0', '#2', '#5', '#6'], spyer)), container);
+    // expect(spyer).toHaveBeenCalledTimes(2);
+    expect(container.textContent).toBe('#0#2#5#6');
+    expect(container.firstChild.childNodes.length).toBe(4);
+
+    render(template(generateKeyNodes(['#0', '#1', '#2', '#3'], spyer)), container);
+    render(template(generateKeyNodes(['#10', '#11'], spyer)), container);
+
+    //expect(spyer).toHaveBeenCalledTimes(10);
+    expect(container.textContent).toBe('#10#11');
+    expect(container.firstChild.childNodes.length).toBe(2);
+
+    render(null, container);
+    expect(container.innerHTML).toBe('');
+    //expect(spyer).toHaveBeenCalledTimes(12);
+  });
+
+  it('should clear all nodes', () => {
+    const spyer = jasmine.createSpy();
+    render(template(generateKeyNodes(['#0', '#1', '#2', '#3'], spyer)), container);
+    render(template(generateKeyNodes([], spyer)), container);
+    expect(container.textContent).toBe('');
+    expect(container.firstChild.childNodes.length).toBe(0);
+    render(template(generateKeyNodes(['#0', '#1', '#2', '#3'], spyer)), container);
+    render(template(generateKeyNodes([], spyer)), container);
+  });
+
+  it('should work with mixed nodes', () => {
+    const spyer = jasmine.createSpy();
+    render(template(generateKeyNodes(['1', '#0', '#1', '#2'], spyer)), container);
+    render(template(generateKeyNodes(['#0', '#1', '#2', '#3'], spyer)), container);
+    expect(container.textContent).toBe('#0#1#2#3');
+    expect(container.firstChild.childNodes.length).toBe(4);
+  });
+  it('should move a key for start to end', () => {
+    const spyer = jasmine.createSpy();
+    render(template(generateKeyNodes(['a', '#0', '#1', '#2'], spyer)), container);
+    render(template(generateKeyNodes(['#0', '#1', '#2', 'a'], spyer)), container);
+    expect(container.textContent).toBe('#0#1#2a');
+    expect(container.firstChild.childNodes.length).toBe(4);
+  });
+  it('should move a key', () => {
+    const spyer = jasmine.createSpy();
+    render(template(generateKeyNodes(['#0', 'a', '#2', '#3'], spyer)), container);
+    render(template(generateKeyNodes(['#0', '#1', 'a', '#3'], spyer)), container);
+    expect(container.textContent).toBe('#0#1a#3');
+    expect(container.firstChild.childNodes.length).toBe(4);
+  });
+
+  /* Skipping spyer from here on */
+
+  it('should move a key', () => {
+    render(template(generateKeyNodes(['#0', 'a', '#2', '#3'])), container);
+    render(template(generateKeyNodes(['#0', '#1', 'a', '#3'])), container);
+    expect(container.textContent).toBe('#0#1a#3');
+    expect(container.firstChild.childNodes.length).toBe(4);
+  });
+  it('should move a key with a size up', () => {
+    render(template(generateKeyNodes(['a', '#1', '#2', '#3'])), container);
+    render(template(generateKeyNodes(['#0', '#1', '#2', '#3', 'a', '#5'])), container);
+    expect(container.textContent).toBe('#0#1#2#3a#5');
+    expect(container.firstChild.childNodes.length).toBe(6);
+  });
+  it('should move a key with a size down', () => {
+    render(template(generateKeyNodes(['a', '#1', '#2', '#3'])), container);
+    render(template(generateKeyNodes(['#0', 'a', '#2'])), container);
+    expect(container.textContent).toBe('#0a#2');
+    expect(container.firstChild.childNodes.length).toBe(3);
+  });
+  it('should avoid unnecessary reordering', () => {
+    render(template(generateKeyNodes(['#0', 'a', '#2'])), container);
+    render(template(generateKeyNodes(['#0', 'a', '#2'])), container);
+    expect(container.textContent).toBe('#0a#2');
+    expect(container.firstChild.childNodes.length).toBe(3);
+  });
+  it('should work with keyed nodes', () => {
+    render(template(generateKeyNodes([0, 1, 2, 3, 4])), container);
+    render(template(generateKeyNodes([1, 2, 3, 4, 0])), container);
+    expect(container.textContent).toBe('12340');
+    expect(container.firstChild.childNodes.length).toBe(5);
+    render(template(generateKeyNodes([0, 1, 2, 3, 4])), container);
+    render(template(generateKeyNodes(['7', '4', '3', '2', '6', 'abc', 'def', '1'])), container);
+    expect(container.textContent).toBe('74326abcdef1');
+    expect(container.firstChild.childNodes.length).toBe(8);
+    render(template(generateKeyNodes(['#0', 'a', '#2'])), container);
+    expect(container.textContent).toBe('#0a#2');
+    expect(container.firstChild.childNodes.length).toBe(3);
+  });
+
+  it('should reorder keys', () => {
+    render(template(generateKeyNodes(['1', '2', '3', '4', 'abc', '6', 'def', '7'])), container);
+    render(template(generateKeyNodes(['7', '4', '3', '2', '6', 'abc', 'def', '1'])), container);
+    expect(container.textContent).toBe('74326abcdef1');
+    expect(container.firstChild.childNodes.length).toBe(8);
+  });
+  it('should remove one key at the start', () => {
+    render(template(generateKeyNodes(['a', 'b', 'c'])), container);
+    render(template(generateKeyNodes(['b', 'c'])), container);
+    expect(container.textContent).toBe('bc');
+    expect(container.firstChild.childNodes.length).toBe(2);
+  });
+  it('should do a complex reverse', () => {
+    render(template(generateKeyNodes(['a', 'b', 'c', 'd'])), container);
+    render(template(generateKeyNodes(['d', 'c', 'b', 'a'])), container);
+    expect(container.textContent).toBe('dcba');
+    expect(container.firstChild.childNodes.length).toBe(4);
+  });
+  it('should remove two keys at the start', () => {
+    render(template(generateKeyNodes(['a', 'b', 'c'])), container);
+    render(template(generateKeyNodes(['c'])), container);
+    expect(container.textContent).toBe('c');
+    expect(container.firstChild.childNodes.length).toBe(1);
+  });
+  it('should add one key to start', () => {
+    render(template(generateKeyNodes(['a', 'b', 'c'])), container);
+    expect(container.textContent).toBe('abc');
+    expect(container.firstChild.childNodes.length).toBe(3);
+    render(template(generateKeyNodes(['a', 'b'])), container);
+    render(template(generateKeyNodes(['a', 'b', 'c'])), container);
+    expect(container.textContent).toBe('abc');
+    expect(container.firstChild.childNodes.length).toBe(3);
+  });
+
+  it('should add two key to start', () => {
+    render(template(generateKeyNodes(['a', 'b', 'c'])), container);
+    expect(container.textContent).toBe('abc');
+    expect(container.firstChild.childNodes.length).toBe(3);
+    render(template(generateKeyNodes(['c'])), container);
+    render(template(generateKeyNodes(['a', 'b', 'c'])), container);
+    expect(container.textContent).toBe('abc');
+    expect(container.firstChild.childNodes.length).toBe(3);
+  });
+  it('should remove one key at the end', () => {
+    render(template(generateKeyNodes(['a', 'b', 'c'])), container);
+    render(template(generateKeyNodes(['a', 'b'])), container);
+    expect(container.textContent).toBe('ab');
+    expect(container.firstChild.childNodes.length).toBe(2);
+  });
+  it('should remove two keys at the end', () => {
+    render(template(generateKeyNodes(['a', 'b', 'c'])), container);
+    render(template(generateKeyNodes(['a'])), container);
+    expect(container.textContent).toBe('a');
+    expect(container.firstChild.childNodes.length).toBe(1);
+  });
+  it('should add one key at the end', () => {
+    render(template(generateKeyNodes(['a', 'b'])), container);
+    render(template(generateKeyNodes(['a', 'b', 'c'])), container);
+    expect(container.textContent).toBe('abc');
+    expect(container.firstChild.childNodes.length).toBe(3);
+  });
+  it('should add two key at the end', () => {
+    render(template(generateKeyNodes(['a'])), container);
+    render(template(generateKeyNodes(['a', 'b', 'c'])), container);
+    expect(container.textContent).toBe('abc');
+    expect(container.firstChild.childNodes.length).toBe(3);
+  });
+  it('should add to end, delete from center & reverse', () => {
+    render(template(generateKeyNodes(['a', 'b', 'c', 'd'])), container);
+    render(template(generateKeyNodes(['e', 'd', 'c', 'a'])), container);
+    expect(container.textContent).toBe('edca');
+    expect(container.firstChild.childNodes.length).toBe(4);
+  });
+  it('should add to the beginning and remove', () => {
+    render(template(generateKeyNodes(['c', 'd'])), container);
+    render(template(generateKeyNodes(['a', 'b', 'c', 'e'])), container);
+    expect(container.textContent).toBe('abce');
+    expect(container.firstChild.childNodes.length).toBe(4);
+  });
+  it('should keep a central pivot', () => {
+    render(template(generateKeyNodes(['1', '2', '3'])), container);
+    render(template(generateKeyNodes(['4', '2', '5'])), container);
+    expect(container.textContent).toBe('425');
+    expect(container.firstChild.childNodes.length).toBe(3);
+  });
+  it('should insert to the middle', () => {
+    render(template(generateKeyNodes(['c', 'd', 'e'])), container);
+    render(template(generateKeyNodes(['a', 'b', 'e'])), container);
+    expect(container.textContent).toBe('abe');
+    expect(container.firstChild.childNodes.length).toBe(3);
+    render(template(generateKeyNodes(['c', 'd', 'e'])), container);
+    render(template(generateKeyNodes(['c', 'd', 'e'])), container);
+    render(template(generateKeyNodes(['a', 'p', 'e'])), container);
+    expect(container.textContent).toBe('ape');
+    expect(container.firstChild.childNodes.length).toBe(3);
+  });
+
+  it('should shuffle, insert and remove', () => {
+    render(template(generateKeyNodes(['a', 'b', 'c', 'd', 'e', 'f', 'g'])), container);
+    render(template(generateKeyNodes(['b', 'c', 'a'])), container);
+    expect(container.textContent).toBe('bca');
+    expect(container.firstChild.childNodes.length).toBe(3);
+  });
+  it('should remove a element from the middle', () => {
+    render(template(generateKeyNodes([1, 2, 3, 4, 5])), container);
+    expect(container.firstChild.childNodes.length).toBe(5);
+    render(template(generateKeyNodes([1, 2, 4, 5])), container);
+    expect(container.textContent).toBe('1245');
+    expect(container.firstChild.childNodes.length).toBe(4);
+  });
+  it('should move a element forward', () => {
+    render(template(generateKeyNodes([1, 2, 3, 4])), container);
+    expect(container.firstChild.childNodes.length).toBe(4);
+    render(template(generateKeyNodes([2, 3, 1, 4])), container);
+    expect(container.textContent).toBe('2314');
+    expect(container.firstChild.childNodes.length).toBe(4);
+    render(template(generateKeyNodes([3, 2, 1, 4])), container);
+    expect(container.textContent).toBe('3214');
+    expect(container.firstChild.childNodes.length).toBe(4);
+    render(template(generateKeyNodes([3, 2, 4, 1])), container);
+    expect(container.textContent).toBe('3241');
+    expect(container.firstChild.childNodes.length).toBe(4);
+  });
+
+  it('should move a element to the end', () => {
+    render(template(generateKeyNodes([1, 2, 3])), container);
+    expect(container.firstChild.childNodes.length).toBe(3);
+    render(template(generateKeyNodes([2, 3, 1])), container);
+    expect(container.textContent).toBe('231');
+    expect(container.firstChild.childNodes.length).toBe(3);
+  });
+  it('should move a element backwards', () => {
+    render(template(generateKeyNodes([1, 2, 3, 4])), container);
+    expect(container.firstChild.childNodes.length).toBe(4);
+    render(template(generateKeyNodes([1, 4, 2, 3])), container);
+    expect(container.textContent).toBe('1423');
+    expect(container.firstChild.childNodes.length).toBe(4);
+  });
+  it('should swap first and last', () => {
+    render(template(generateKeyNodes([1, 2, 3, 4])), container);
+    expect(container.firstChild.childNodes.length).toBe(4);
+    render(template(generateKeyNodes([4, 2, 3, 1])), container);
+    expect(container.textContent).toBe('4231');
+    expect(container.firstChild.childNodes.length).toBe(4);
+    render(template(generateKeyNodes([1, 2, 3, 4])), container);
+    expect(container.firstChild.childNodes.length).toBe(4);
+  });
+
+  it('should move to left and replace', () => {
+    render(template(generateKeyNodes([1, 2, 3, 4, 5])), container);
+    expect(container.firstChild.childNodes.length).toBe(5);
+    render(template(generateKeyNodes([4, 1, 2, 3, 6])), container);
+    expect(container.textContent).toBe('41236');
+    expect(container.firstChild.childNodes.length).toBe(5);
+    render(template(generateKeyNodes([4, 5, 2, 3, 0])), container);
+    expect(container.textContent).toBe('45230');
+    render(template(generateKeyNodes([1, 2, 3, 4, 5])), container);
+    expect(container.firstChild.childNodes.length).toBe(5);
+  });
+
+  it('should move to left and leave a hole', () => {
+    render(template(generateKeyNodes([1, 4, 5])), container);
+    expect(container.firstChild.childNodes.length).toBe(3);
+    render(template(generateKeyNodes([4, 6])), container);
+    expect(container.textContent).toBe('46');
+    expect(container.firstChild.childNodes.length).toBe(2);
+  });
+  it('should do something', () => {
+    render(template(generateKeyNodes([0, 1, 2, 3, 4, 5])), container);
+    expect(container.firstChild.childNodes.length).toBe(6);
+    render(template(generateKeyNodes([4, 3, 2, 1, 5, 0])), container);
+    expect(container.textContent).toBe('432150');
+    expect(container.firstChild.childNodes.length).toBe(6);
+  });
+
+  it('should cycle order correctly', () => {
+    render(template(generateKeyNodes([1, 2, 3, 4])), container);
+    expect(container.firstChild.childNodes.length).toBe(4);
+    expect(container.textContent).toBe('1234');
+    render(template(generateKeyNodes([2, 3, 4, 1])), container);
+    expect(container.firstChild.childNodes.length).toBe(4);
+    expect(container.textContent).toBe('2341');
+    render(template(generateKeyNodes([3, 4, 1, 2])), container);
+    expect(container.firstChild.childNodes.length).toBe(4);
+    expect(container.textContent).toBe('3412');
+    render(template(generateKeyNodes([4, 1, 2, 3])), container);
+    expect(container.firstChild.childNodes.length).toBe(4);
+    expect(container.textContent).toBe('4123');
+    render(template(generateKeyNodes([1, 2, 3, 4])), container);
+    expect(container.firstChild.childNodes.length).toBe(4);
+    expect(container.textContent).toBe('1234');
+  });
+
+  it('should cycle order correctly in the other direction', () => {
+    render(template(generateKeyNodes([1, 2, 3, 4])), container);
+    expect(container.firstChild.childNodes.length).toBe(4);
+    expect(container.textContent).toBe('1234');
+    render(template(generateKeyNodes([4, 1, 2, 3])), container);
+    expect(container.firstChild.childNodes.length).toBe(4);
+    expect(container.textContent).toBe('4123');
+    render(template(generateKeyNodes([3, 4, 1, 2])), container);
+    expect(container.firstChild.childNodes.length).toBe(4);
+    expect(container.textContent).toBe('3412');
+    render(template(generateKeyNodes([2, 3, 4, 1])), container);
+    expect(container.firstChild.childNodes.length).toBe(4);
+    expect(container.textContent).toBe('2341');
+    render(template(generateKeyNodes([1, 2, 3, 4])), container);
+    expect(container.firstChild.childNodes.length).toBe(4);
+    expect(container.textContent).toBe('1234');
+  });
+
+  it('should allow any character as a key', () => {
+    render(template(generateKeyNodes(['<WEIRD/&\\key>'])), container);
+    render(template(generateKeyNodes(['INSANE/(/&\\key', '<CRAZY/&\\key>', '<WEIRD/&\\key>'])), container);
+    expect(container.textContent).toBe('INSANE/(/&\\key<CRAZY/&\\key><WEIRD/&\\key>');
+    expect(container.firstChild.childNodes.length).toBe(3);
+  });
+
+  it('should reorder nodes', () => {
+    render(template(generateKeyNodes(['7', '4', '3', '2', '6', 'abc', 'def', '1'])), container);
+    expect(container.textContent).toBe('74326abcdef1');
+    expect(container.firstChild.childNodes.length).toBe(8);
+    render(template(generateKeyNodes(['1', '2', '3', '4', 'abc', '6', 'def', '7'])), container);
+    render(template(generateKeyNodes(['7', '4', '3', '2', '6', 'abc', 'def', '1'])), container);
+    expect(container.textContent).toBe('74326abcdef1');
+    expect(container.firstChild.childNodes.length).toBe(8);
+    render(template(generateKeyNodes(['7', '4', '3', '2', '6', 'abc', 'def', '1'])), container);
+    expect(container.textContent).toBe('74326abcdef1');
+    expect(container.firstChild.childNodes.length).toBe(8);
+  });
+
+  it('should do a advanced shuffle - numbers and letters', () => {
+    render(template(generateKeyNodes(['a', 'b', 'c', 'd', 1, 2, 3])), container);
+    expect(container.textContent).toBe('abcd123');
+    expect(container.firstChild.childNodes.length).toBe(7);
+    render(template(generateKeyNodes([1, 'e', 2, 'b', 'f', 'g', 'c', 'a', 3])), container);
+    expect(container.textContent).toBe('1e2bfgca3');
+    expect(container.firstChild.childNodes.length).toBe(9);
+    render(template(generateKeyNodes(['a', 'b', 'c', 'd', 1, 2, 3])), container);
+    expect(container.textContent).toBe('abcd123');
+    expect(container.firstChild.childNodes.length).toBe(7);
+    render(template(generateKeyNodes([0, 'e', 2, 'b', 'f', 'g', 'c', 'a', 4])), container);
+    expect(container.textContent).toBe('0e2bfgca4');
+    expect(container.firstChild.childNodes.length).toBe(9);
+    render(template(generateKeyNodes(['a', 'b', 'c', 'd', 1, 2, 3])), container);
+    expect(container.textContent).toBe('abcd123');
+    expect(container.firstChild.childNodes.length).toBe(7);
+    render(template(generateKeyNodes([1, 'e', 2, 'b', 'f', 'g', 'c', 'a', 3])), container);
+    expect(container.textContent).toBe('1e2bfgca3');
+    expect(container.firstChild.childNodes.length).toBe(9);
+  });
+
+  it('should do a complex removal at the beginning', () => {
+    render(template(generateKeyNodes(['a', 'b', 'c', 'd'])), container);
+    expect(container.textContent).toBe('abcd');
+    expect(container.firstChild.childNodes.length).toBe(4);
+    render(template(generateKeyNodes(['c', 'd'])), container);
+    expect(container.textContent).toBe('cd');
+    expect(container.firstChild.childNodes.length).toBe(2);
+    render(template(generateKeyNodes(['a', 'b', 'c', 'd'])), container);
+    expect(container.textContent).toBe('abcd');
+    expect(container.firstChild.childNodes.length).toBe(4);
+    render(template(generateKeyNodes(['a', 'b', 'c', 'd'])), container);
+    expect(container.textContent).toBe('abcd');
+    expect(container.firstChild.childNodes.length).toBe(4);
+  });
+
+  it('should do move and sync nodes from right to left', () => {
+    render(template(generateKeyNodes(['a', 'b', 'c', 'd'])), container);
+    expect(container.textContent).toBe('abcd');
+    expect(container.firstChild.childNodes.length).toBe(4);
+    render(template(generateKeyNodes(['c', 'l', 1, 2, 3, 4, 5, 6, 7, 8, 9, 'd', 'g', 'b'])), container);
+    expect(container.textContent).toBe('cl123456789dgb');
+    expect(container.firstChild.childNodes.length).toBe(14);
+  });
+
+  describe('Should handle massive large arrays', () => {
+    let items;
+
+    beforeEach(function () {
+      items = new Array(1000);
+      for (let i = 0; i < 1000; i++) {
+        items[i] = i;
+      }
+    });
+
+    it('Should handle massive large arrays - initial', () => {
+      render(template(generateKeyNodes(items)), container);
+
+      expect(container.textContent).toEqual(items.join(''));
+    });
+
+    it('Should handle massive arrays shifting once by 2', () => {
+      items = items.concat(items.splice(0, 2));
+      render(template(generateKeyNodes(items)), container);
+
+      expect(container.textContent).toEqual(items.join(''));
+    });
+
+    for (let i = 0; i < 10; i++) {
+      // eslint-disable-next-line
+      it('Should handle massive arrays shifting ' + i + ' times by ' + i, () => {
+        for (let j = 0; j < i; j++) {
+          items = items.concat(items.splice(i, j));
+        }
+        render(template(generateKeyNodes(items)), container);
+        expect(container.textContent).toEqual(items.join(''));
+      });
+    }
+  });
+
+  describe('Calendar like layout', () => {
+    class Animated extends Component {
+      componentDidAppear(dom) {
+        // Trigger animation code paths on add
+      }
+      componentWillDisappear(dom, done) {
+        // Trigger animation code paths on remove
+        done();
+      }
+      render({ children }) {
+        return <div>{children}</div>;
+      }
+    }
+
+    function o(text) {
+      return createElement(
+        Animated,
+        {
+          key: 'o' + text
+        },
+        ',o' + text
+      );
+    }
+
+    function d(text) {
+      return createElement(
+        Animated,
+        {
+          key: 'd' + text
+        },
+        ',d' + text
+      );
+    }
+
+    function wk(text) {
+      return createElement(
+        Animated,
+        {
+          key: 'wk' + text
+        },
+        ',wk' + text
+      );
+    }
+
+    it('Should do complex suffle without duplications', () => {
+      const layout1 = [
+        wk(31),
+        d(1),
+        d(2),
+        d(3),
+        d(4),
+        d(5),
+        d(6),
+        d(7),
+        wk(32),
+        d(8),
+        d(9),
+        d(10),
+        d(11),
+        d(12),
+        d(13),
+        d(14),
+        wk(33),
+        d(15),
+        d(16),
+        d(17),
+        d(18),
+        d(19),
+        d(20),
+        d(21),
+        wk(34),
+        d(22),
+        d(23),
+        d(24),
+        d(25),
+        d(26),
+        d(27),
+        d(28),
+        wk(35),
+        d(29),
+        d(30),
+        d(31),
+        o(1),
+        o(2),
+        o(3),
+        o(4),
+        wk(36),
+        o(5),
+        o(6),
+        o(7),
+        o(8),
+        o(9),
+        o(10),
+        o(11)
+      ];
+      render(template(layout1), container);
+
+      expect(container.textContent).toBe(
+        ',wk31,d1,d2,d3,d4,d5,d6,d7,wk32,d8,d9,d10,d11,d12,d13,d14,wk33,d15,d16,d17,d18,d19,d20,d21,wk34,d22,d23,d24,d25,d26,d27,d28,wk35,d29,d30,d31,o1,o2,o3,o4,wk36,o5,o6,o7,o8,o9,o10,o11'
+      );
+
+      const layout2 = [
+        wk(35),
+        o(29),
+        o(30),
+        o(31),
+        d(1),
+        d(2),
+        d(3),
+        d(4),
+        wk(36),
+        d(5),
+        d(6),
+        d(7),
+        d(8),
+        d(9),
+        d(10),
+        d(11),
+        wk(37),
+        d(12),
+        d(13),
+        d(14),
+        d(15),
+        d(16),
+        d(17),
+        d(18),
+        wk(38),
+        d(19),
+        d(20),
+        d(21),
+        d(22),
+        d(23),
+        d(24),
+        d(25),
+        wk(39),
+        d(26),
+        d(27),
+        d(28),
+        d(29),
+        d(30),
+        o(1),
+        o(2),
+        wk(40),
+        o(3),
+        o(4),
+        o(5),
+        o(6),
+        o(7),
+        o(8),
+        o(9)
+      ];
+      render(template(layout2), container);
+
+      expect(container.textContent).toBe(
+        ',wk35,o29,o30,o31,d1,d2,d3,d4,wk36,d5,d6,d7,d8,d9,d10,d11,wk37,d12,d13,d14,d15,d16,d17,d18,wk38,d19,d20,d21,d22,d23,d24,d25,wk39,d26,d27,d28,d29,d30,o1,o2,wk40,o3,o4,o5,o6,o7,o8,o9'
+      );
+    });
+  });
+});
+
+function factory(spyer) {
+  return {
+    Tag: ({ children }) => {
+      return <div>{children}</div>;
+    },
+    onComponentDidAppear(dom) {
+      spyer && spyer('didAppear');
+    },
+    onComponentWillDisappear(dom, props, callback) {
+      spyer && spyer('willDisappear');
+      callback();
+    }
+  };
+}
+
+function generateKeyNodes(array, spyer) {
+  let i, id, key;
+  const children = [];
+  let newKey;
+  const { Tag, onComponentDidAppear, onComponentWillDisappear } = factory(spyer);
+
+  for (i = 0; i < array.length; i++) {
+    id = key = array[i];
+    if (key !== null && (typeof key !== 'string' || key[0] !== '#')) {
+      newKey = key;
+    } else {
+      newKey = null;
+    }
+
+    children.push(
+      <Tag key={newKey} id={String(id)} onComponentDidAppear={onComponentDidAppear} onComponentWillDisappear={onComponentWillDisappear} >
+        {id}
+      </Tag>
+    );
+  }
+  return children;
+}


### PR DESCRIPTION
So this PR adds animation hooks to functional components. They are functionally equivalent to class components so you can switch back and forth without having to think too much about it.

Inferno-animation has been updated to expose helper methods for functional components and AnimatedComponent uses the same methods for consistency.

I will update the docs accordingly when this PR is merged.

Note: you will probably want to run the performance tests again since this affects functional component code paths and I am guessing they are widely used in benchmarks.

QUESTION: When working on the functional components, I am passing props to allow controlling what animation is used. Realised right at the end that we might want to pass context too. That would make it possible to provide an animation controller to functional components (it would be available as this.context on class components). This could be useful if you want to coordinate/implement animations using Javascript. Since I don't personally use it, I didn't want to throw it in "just in case". HOWEVER, if we add it now we could have a more consistent API `onComponentWillDisappear(dom, props, context, callback)` instead of `onComponentWillDisappear(dom, props, callback, context)` which would be the case if we add it later.

Note: I moved `mountFunctionalComponentCallbacks` to `mountFunctionalComponent` for consistency, there was no comment explaining why it differed from the other cases in the same statement. Keeping it where it was would make the code less readable but if it was an optimisation I will have to look at other ways to maintain consistency between the class component and functional component code paths.

Note: The commits from April 2 are already merged in 4148c0e2b

