### PR TITLE
Update package.json to include the repository

### DIFF
--- a/packages/inferno-animation/package.json
+++ b/packages/inferno-animation/package.json
@@ -8,6 +8,11 @@
     "email": "sebastian@urbantalk.se",
     "url": "https://github.com/jhsware"
   },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/infernojs/inferno.git",
+    "directory": "packages/inferno-animation"
+  },
   "bugs": {
     "url": "https://github.com/infernojs/inferno/issues"
   },

--- a/packages/inferno-clone-vnode/package.json
+++ b/packages/inferno-clone-vnode/package.json
@@ -8,6 +8,11 @@
     "email": "sampo.kivisto@live.fi",
     "url": "https://github.com/havunen"
   },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/infernojs/inferno.git",
+    "directory": "packages/inferno-clone-vnode"
+  },
   "bugs": {
     "url": "https://github.com/infernojs/inferno/issues"
   },

--- a/packages/inferno-compat/package.json
+++ b/packages/inferno-compat/package.json
@@ -7,6 +7,11 @@
     "name": "Dominic Gannaway",
     "email": "dg@domgan.com"
   },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/infernojs/inferno.git",
+    "directory": "packages/inferno-compat"
+  },
   "bugs": {
     "url": "https://github.com/infernojs/inferno/issues"
   },

--- a/packages/inferno-create-class/package.json
+++ b/packages/inferno-create-class/package.json
@@ -7,6 +7,11 @@
     "name": "Dominic Gannaway",
     "email": "dg@domgan.com"
   },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/infernojs/inferno.git",
+    "directory": "packages/inferno-create-class"
+  },
   "bugs": {
     "url": "https://github.com/infernojs/inferno/issues"
   },

--- a/packages/inferno-create-element/package.json
+++ b/packages/inferno-create-element/package.json
@@ -7,6 +7,11 @@
     "name": "Dominic Gannaway",
     "email": "dg@domgan.com"
   },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/infernojs/inferno.git",
+    "directory": "packages/inferno-create-element"
+  },
   "bugs": {
     "url": "https://github.com/infernojs/inferno/issues"
   },

--- a/packages/inferno-hydrate/package.json
+++ b/packages/inferno-hydrate/package.json
@@ -8,6 +8,11 @@
     "email": "sampo.kivisto@live.fi",
     "url": "https://github.com/havunen"
   },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/infernojs/inferno.git",
+    "directory": "packages/inferno-hydrate"
+  },
   "bugs": {
     "url": "https://github.com/infernojs/inferno/issues"
   },

--- a/packages/inferno-utils/package.json
+++ b/packages/inferno-utils/package.json
@@ -5,6 +5,11 @@
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/infernojs/inferno.git",
+    "directory": "packages/inferno-utils"
+  },
   "devDependencies": {
     "inferno-shared": "7.4.8",
     "inferno-vnode-flags": "7.4.8"


### PR DESCRIPTION
NOTE: This is not a bot. This change was made by and comments will be reviewed by humans. We are using this service account to be able to track the overall progress.

With the rise in supply chain attacks and OSS dependencies being used as a attack vector, Microsoft is working with our ecosystem partners, such as the Linux Foundation's OpenSSF, to enable OSS consumers to track packages back to their public sources.

We've identified that the following packages published to NPM do not report where sources can be found, typically accomplished by including a link to your GitHub repository in your package.json REPOSITORY field. This PR was created to add this value, ensuring future releases will include this provenance information.

If you do not want us to create such PRs against your GitHub repositories, or wish to provide any other feedback, please comment on this PR.

Published NPM packages with repository information:
• inferno-animation
• inferno-clone-vnode
• inferno-compat
• inferno-create-class
• inferno-create-element
• inferno-hydrate
• inferno-utils