### PR TITLE
inferno-mobx observer throws for incompatible class components

### DIFF
--- a/packages/inferno-mobx/__tests__/observer.spec.jsx
+++ b/packages/inferno-mobx/__tests__/observer.spec.jsx
@@ -535,6 +535,29 @@ describe('Mobx Observer', () => {
     expect(container.querySelector('span').textContent).toBe('1');
   });
 
+  it('observer should throw on new life cycle hooks', () => {
+    class A extends Component {
+      static getDerivedStateFromProps() {
+        return {};
+      }
+    }
+    expect(() => observer(A)).toThrow();
+    class B extends Component {
+      getSnapshotBeforeUpdate() {
+        return {};
+      }
+    }
+    expect(() => observer(B)).toThrow();
+    expect(() =>
+      observer({
+        render: () => undefined,
+        getSnapshotBeforeUpdate: () => {
+          return {};
+        }
+      })
+    ).toThrow();
+  });
+
   // TODO: Reaction Scheduler
   // it('parent / childs render in the right order', done => {
   //   // See: https://jsfiddle.net/gkaemmer/q1kv7hbL/13/

--- a/packages/inferno-mobx/src/observer.ts
+++ b/packages/inferno-mobx/src/observer.ts
@@ -301,6 +301,14 @@ export function observer(arg1, arg2?) {
   }
 
   const target = component.prototype || component;
+  if (process.env.NODE_ENV !== 'production') {
+    if (component.prototype && typeof component.getDerivedStateFromProps === 'function') {
+      throw new Error("inferno-mobx 'observer' is incompatible with the 'getDerivedStateFromProps' life cycle hook.");
+    }
+    if (typeof target.getSnapshotBeforeUpdate === 'function') {
+      throw new Error("inferno-mobx 'observer' is incompatible with the 'getSnapshotBeforeUpdate' life cycle hook.");
+    }
+  }
   mixinLifecycleEvents(target);
   component.isMobXReactObserver = true;
   return component;


### PR DESCRIPTION
**Objective**

This PR makes inferno-mobx `observer` throw when passed a class component that implements the incompatible new life cycle hooks. This behavior is disabled in production builds (as determined by `process.env.NODE_ENV`) as the goal should be to eliminate the issue before reaching production.

Tests were added to check that an error is thrown for appropriate class components.

**Closes Issue**

It closes Issue #1585.
