### PR TITLE
[inferno-mobx] Forward exceptions thrown by render so MobX does not eat them

### DIFF
--- a/packages/inferno-mobx/README.md
+++ b/packages/inferno-mobx/README.md
@@ -259,7 +259,7 @@ The differences to be aware of when switching from `observer` to `observerPatch`
 2. `observerPatch` returns `void` instead of returning the class it was applied to
 3. `observerPatch` will not have the observer call `this.componentWillReact()` if such a member exists
 4. `observerPatch` does not add a `shouldComponentUpdate` hook to classes that do not have one
-5. `observerPatch` will not catch exceptions thrown by `render` and forward them to `errorsReporter`
+5. `observerPatch` will not forward exceptions thrown by `render` to `errorsReporter`
 6. `observerPatch` ignores `useStaticRendering(true)`
 7. `observerPatch` will not emit events through `renderReporter` that list how long `render` took
 8. `observerPatch` does not make `this.props` nor `this.state` observable
@@ -275,12 +275,7 @@ For point 4, you can implement your own `shouldComponentUpdate` hook is you want
 The `shouldComponentUpdate` does not affect re-renders triggered by MobX obervables being modified.
 So it exists for when new properties are set or `this.setState` is used.
 
-Errors sent to `errorsReporter` as mentioned in point 5 could then be sent to a custom handler provided to `onError`.
-For exceptions occuring in your render method, catch them in the method and forward to your handler.
-This cuts out extra intermediate steps.
-Otherwise, they will go to the MobX global Reaction error handler set with `onReactionError`.
-Which is where they may have been going anyways.
-There was no unit test checking this behavior.
+For point 5, you can intercept the exceptions in your render method and send them to a handler if desired.
 
 For point 6, all your components other than those passed to `observer` already ignore it.
 If there is demand, generating warning messages might return `useStaticRendering(true)` is called.

--- a/packages/inferno-mobx/__tests__/observer.spec.jsx
+++ b/packages/inferno-mobx/__tests__/observer.spec.jsx
@@ -1,6 +1,6 @@
 import { Component, render } from 'inferno';
 import * as mobx from 'mobx';
-import { inject, observer, Observer, trackComponents, useStaticRendering } from 'inferno-mobx';
+import { inject, observer, Observer, onError, trackComponents, useStaticRendering } from 'inferno-mobx';
 import { createClass } from 'inferno-create-class';
 
 const store = mobx.observable({
@@ -556,6 +556,25 @@ describe('Mobx Observer', () => {
         }
       })
     ).toThrow();
+  });
+
+  it('observer should send exception to errorsReporter and re-thrown', () => {
+    const exception = new Error('dummy error');
+    let reported;
+    const off = onError((error) => {
+      reported = error;
+    });
+    class Faulty extends Component {
+      render() {
+        throw exception;
+      }
+    }
+    observer(Faulty);
+    expect(() => {
+      render(<Faulty />, container);
+    }).toThrow(exception);
+    expect(reported).toEqual(exception);
+    off();
   });
 
   // TODO: Reaction Scheduler

--- a/packages/inferno-mobx/__tests__/observerPatch.spec.jsx
+++ b/packages/inferno-mobx/__tests__/observerPatch.spec.jsx
@@ -369,6 +369,19 @@ describe('Mobx Observer Patch', () => {
     done();
   });
 
+  it('observerPatch should keep MobX from eating exceptions', () => {
+    const exception = new Error('dummy error');
+    class Faulty extends Component {
+      render() {
+        throw exception;
+      }
+    }
+    observerPatch(Faulty);
+    expect(() => {
+      render(<Faulty />, container);
+    }).toThrow(exception);
+  });
+
   // it('it rerenders correctly if some props are non-observables - 1', done => {
   //   let renderCount = 0;
   //   let odata = observable({ x: 1 })

--- a/packages/inferno-mobx/src/observerPatch.ts
+++ b/packages/inferno-mobx/src/observerPatch.ts
@@ -13,10 +13,19 @@ function makeObserverRender<R extends Render>(update: () => void, render: R, nam
   const track = reactor.track.bind(reactor);
   const observer = function (this, ...parameters: Parameters<typeof render>) {
     let rendered: RenderReturn;
+    let caught;
     track(() => {
-      rendered = render.apply(this, parameters);
+      try {
+        rendered = render.apply(this, parameters);
+      } catch(error) {
+        caught = error;
+      }
     });
-    return rendered;
+    if (caught) {
+      throw caught;
+    } else {
+      return rendered;
+    }
   } as ObserverRender<R>;
   observer.dispose = reactor.dispose.bind(reactor);
   return observer;


### PR DESCRIPTION
**Objective**

This PR fixes the render wrapper implemented in `observerPatch` not catching and forwarding exceptions from `render`. Which would lead to MobX sending them to its global error handling call back.
