### PR TITLE
Adapt to new history blocking API

### DIFF
--- a/packages/inferno-router/src/Prompt.ts
+++ b/packages/inferno-router/src/Prompt.ts
@@ -17,7 +17,12 @@ export class Prompt extends Component<IPromptProps, any> {
       this.unblock();
     }
 
-    this.unblock = this.context.router.history.block(message);
+    this.unblock = this.context.router.history.block((tx) => {
+      if (message && window.confirm(message)) {
+        this.unblock();
+        tx.retry();
+      }
+    });
   }
 
   public disable() {


### PR DESCRIPTION
**Summary**

* The `<Prompt>` component is currently broken, throwing an exception whenever it should prompt, breaking the page.
* The 'history' project changed the API used to block transitions, starting with v5.x.
* Instead of accepting a message string, it now requires a callback function that handles the browser prompt itself.

**Objective**

This PR fixes an exception when using the `<Prompt>` router component. The regression was probably introduced with a95f57ea, when the `history` dependency was updated to v5.x.
This version change came with a breaking change of the `history.block()` API that is used to block transitions between pages (i.e. the sole purpose of the `<Prompt>` component).

The v5 API _requires_ the parameter of `history.block(...)` to be a function, whereas older versions _also_ accepted a string.  
See the documentation of the history project: [Blocking Transitions (v4)](https://github.com/remix-run/history/blob/3e9dab413f4eda8d6bce565388c5ddb7aeff9f7e/docs/blocking-transitions.md) vs [Blocking Transitions (v5)](https://github.com/remix-run/history/blob/3e9dab413f4eda8d6bce565388c5ddb7aeff9f7e/docs/blocking-transitions.md)

This PR uses the suggested code from the history project to restore the functionality as it was before.

**How to test**

I am not sure how this can be tested automatically. If anyone can give me a hint I'm happy to add a test.

It can easily be verified manually though:

1. Add the `<Prompt>` component to the 'About' page of the _inferno-router-demo_ ([like that](https://github.com/fheft/inferno/commit/dc85a6520f0ffbfa7102f2ed7cb3a691c54aa034))
2. Start the example project, navigate to the 'About' page, try to navigate back
3. Nothing happens, exception in the browser console
4. Using the fix from this PR, it will work as expected.