### PR TITLE
Added tests for SSR with inferno-router and fix bug in <Switch> (rebased on master)

### DIFF
--- a/packages/inferno-router/__tests__/loaderOnRoute.spec.tsx
+++ b/packages/inferno-router/__tests__/loaderOnRoute.spec.tsx
@@ -693,4 +693,44 @@ describe('Resolve loaders during server side rendering', () => {
     const result = await resolveLoaders(loaderEntries);
     expect(result).toEqual(initialData);
   });
+
+
+  it('Can resolve with sub classed Route', async () => {
+    class MyRoute extends Route {
+      constructor(props, context) {
+        super(props, context);
+      }
+    }
+    const TEXT = 'bubblegum';
+    const Component = (props) => {
+      const res = useLoaderData(props);
+      return <h1>{res?.message}</h1>;
+    };
+
+    const loaderFuncNoHit = async () => {
+      return { message: 'no' };
+    };
+    const loaderFunc = async () => {
+      return { message: TEXT };
+    };
+
+    const initialData = {
+      '/flowers': { res: await loaderFunc() },
+      '/flowers/birds': { res: await loaderFunc() }
+    };
+
+    const app = (
+      <StaticRouter context={{}} location="/flowers/birds">
+        <MyRoute path="/flowers" render={Component} loader={loaderFunc}>
+          <MyRoute path="/flowers/birds" render={Component} loader={loaderFunc} />
+          <MyRoute path="/flowers/bees" render={Component} loader={loaderFuncNoHit} />
+          {null}
+        </MyRoute>
+      </StaticRouter>
+    );
+
+    const loaderEntries = traverseLoaders('/flowers/birds', app);
+    const result = await resolveLoaders(loaderEntries);
+    expect(result).toEqual(initialData);
+  });
 });


### PR DESCRIPTION
(rebased on master, all tests passing)

Using Switch with inferno-router was missing tests for SSR. Adding them revealed a bug where all matching routes that are children of Switch would be returned by traverseLoaders. Whereas the UI would render correctly, this would cause unnecessary calls to API:s.

Also, tightened check that path matches are only done on Route Components and not any Component that looks like a route. The current behaviour could cause unexpected behaviour.

A sidenote: While implementing function _isRoute(node: any) I was surprised that I needed a fallback check for inheritance of Route when routes where passed as an array (see comment in code). This feels lika an inconsistency in Inferno where array and component implementation gives slightly different results. Just wanted to mention it, I haven't investigated any further.