### PR TITLE
Fix attachEvent type error

### DIFF
--- a/packages/inferno/src/DOM/events/delegation.ts
+++ b/packages/inferno/src/DOM/events/delegation.ts
@@ -184,9 +184,7 @@ function rootEvent(name: string): (event: SemiSyntheticEvent<any>) => void {
 function attachEventToDocument(
   name: string,
 ): (event: SemiSyntheticEvent<any>) => void {
-  const attachedEvent = rootEvent(name);
-  // @ts-expect-error TODO: FIXME
+  const attachedEvent = rootEvent(name);  
   document.addEventListener(normalizeEventName(name), attachedEvent);
-
   return attachedEvent;
 }

--- a/packages/inferno/src/DOM/events/delegation.ts
+++ b/packages/inferno/src/DOM/events/delegation.ts
@@ -184,7 +184,7 @@ function rootEvent(name: string): (event: SemiSyntheticEvent<any>) => void {
 function attachEventToDocument(
   name: string,
 ): (event: SemiSyntheticEvent<any>) => void {
-  const attachedEvent = rootEvent(name);  
+  const attachedEvent = rootEvent(name);
   document.addEventListener(normalizeEventName(name), attachedEvent);
   return attachedEvent;
 }

--- a/packages/inferno/src/DOM/utils/common.ts
+++ b/packages/inferno/src/DOM/utils/common.ts
@@ -33,7 +33,7 @@ if (process.env.NODE_ENV !== 'production') {
   Object.freeze(EMPTY_OBJ);
 }
 
-export function normalizeEventName(name): string {
+export function normalizeEventName(name): keyof DocumentEventMap {
   return name.substring(2).toLowerCase();
 }
 

--- a/packages/inferno/src/core/types.ts
+++ b/packages/inferno/src/core/types.ts
@@ -79,8 +79,8 @@ export interface SemiSyntheticEvent<T> extends Event {
    * A reference to the element on which the event listener is registered.
    */
   currentTarget: EventTarget & T;
-  isDefaultPrevented: () => boolean;
-  isPropagationStopped: () => boolean;
+  isDefaultPrevented?: () => boolean;
+  isPropagationStopped?: () => boolean;
 }
 
 export type ClipboardEvent<T> = SemiSyntheticEvent<T> & NativeClipboardEvent;


### PR DESCRIPTION
This fixes a type error in attachEventToDocument method.

A note though, perhaps we should remove:
```
  isDefaultPrevented: () => boolean;
  isPropagationStopped: () => boolean;
```

The implementation was moved to core from inferno-compat and are specifically geared towards React-compatibility. Given how much React has evolved, perhaps it isn't worth keeping React-fixes in the core Inferno code base.

[ref 1](https://github.com/infernojs/inferno/commit/e6666bd61db2ed6ef436d01df601597d4e1cf4b8)
[ref 2](https://github.com/infernojs/inferno/issues/1442)