### PR TITLE
Feature: Async component rendering

### DIFF
--- a/packages/inferno-animation/__tests__/animatedAllComponent.spec.tsx
+++ b/packages/inferno-animation/__tests__/animatedAllComponent.spec.tsx
@@ -150,14 +150,14 @@ describe('inferno-animation AnimatedAllComponent', () => {
     });
   });
 
-  it('should render class component extending AnimatedAllComponent to a string', () => {
+  it('should render class component extending AnimatedAllComponent to a string', async () => {
     class MyComponent extends AnimatedAllComponent<any, any> {
       public render({ children }): InfernoNode {
         return <div>{children}</div>;
       }
     }
 
-    const outputStr = renderToString(<MyComponent>1</MyComponent>);
+    const outputStr = await renderToString(<MyComponent>1</MyComponent>);
     expect(outputStr).toBe('<div>1</div>');
   });
 });
@@ -350,7 +350,7 @@ describe('inferno-animation animated functional component', () => {
     });
   });
 
-  it('should render class component extending AnimatedAllComponent to a string', () => {
+  it('should render class component extending AnimatedAllComponent to a string', async () => {
     const MyComponent = ({ children }): InfernoNode => {
       return <div>{children}</div>;
     };
@@ -361,7 +361,7 @@ describe('inferno-animation animated functional component', () => {
       onComponentWillMove: componentWillMove,
     };
 
-    const outputStr = renderToString(<MyComponent {...anim}>1</MyComponent>);
+    const outputStr = await renderToString(<MyComponent {...anim}>1</MyComponent>);
     expect(outputStr).toBe('<div>1</div>');
   });
 });

--- a/packages/inferno-animation/__tests__/animatedComponent.spec.tsx
+++ b/packages/inferno-animation/__tests__/animatedComponent.spec.tsx
@@ -149,14 +149,14 @@ describe('inferno-animation AnimatedComponent', () => {
     });
   });
 
-  it('should render class component extending AnimatedComponent to a string', () => {
+  it('should render class component extending AnimatedComponent to a string', async () => {
     class MyComponent extends AnimatedComponent<any, any> {
       public render({ children }): InfernoNode {
         return <div>{children}</div>;
       }
     }
 
-    const outputStr = renderToString(<MyComponent>1</MyComponent>);
+    const outputStr = await renderToString(<MyComponent>1</MyComponent>);
     expect(outputStr).toBe('<div>1</div>');
   });
 });
@@ -346,7 +346,7 @@ describe('inferno-animation animated functional component', () => {
     });
   });
 
-  it('should render class component extending AnimatedComponent to a string', () => {
+  it('should render class component extending AnimatedComponent to a string', async () => {
     const MyComponent = ({ children }): InfernoNode => {
       return <div>{children}</div>;
     };
@@ -356,7 +356,7 @@ describe('inferno-animation animated functional component', () => {
       onComponentWillDisappear: componentWillDisappear,
     };
 
-    const outputStr = renderToString(<MyComponent {...anim}>1</MyComponent>);
+    const outputStr = await renderToString(<MyComponent {...anim}>1</MyComponent>);
     expect(outputStr).toBe('<div>1</div>');
   });
 });

--- a/packages/inferno-animation/__tests__/animatedMoveComponent.spec.tsx
+++ b/packages/inferno-animation/__tests__/animatedMoveComponent.spec.tsx
@@ -145,19 +145,19 @@ describe('inferno-animation AnimatedMoveComponent', () => {
     });
   });
 
-  it('should render class component extending AnimatedMoveComponent to a string', () => {
+  it('should render class component extending AnimatedMoveComponent to a string', async () => {
     class MyComponent extends AnimatedMoveComponent<any, any> {
       public render({ children }): InfernoNode {
         return <div>{children}</div>;
       }
     }
 
-    const outputStr = renderToString(<MyComponent>1</MyComponent>);
+    const outputStr = await renderToString(<MyComponent>1</MyComponent>);
     expect(outputStr).toBe('<div>1</div>');
   });
 });
 
-describe('inferno-animation animated functional component', () => {
+describe('inferno-animation animated functional component',() => {
   let container;
 
   beforeEach(function () {
@@ -335,7 +335,7 @@ describe('inferno-animation animated functional component', () => {
     });
   });
 
-  it('should render class component extending AnimatedMoveComponent to a string', () => {
+  it('should render class component extending AnimatedMoveComponent to a string', async () => {
     const MyComponent = ({ children }): InfernoNode => {
       return <div>{children}</div>;
     };
@@ -344,7 +344,7 @@ describe('inferno-animation animated functional component', () => {
       onComponentWillMove: componentWillMove,
     };
 
-    const outputStr = renderToString(<MyComponent {...anim}>1</MyComponent>);
+    const outputStr = await renderToString(<MyComponent {...anim}>1</MyComponent>);
     expect(outputStr).toBe('<div>1</div>');
   });
 });

--- a/packages/inferno-create-element/src/index.ts
+++ b/packages/inferno-create-element/src/index.ts
@@ -13,6 +13,7 @@ import {
   isNullOrUndef,
   isString,
   isUndefined,
+  throwError,
 } from 'inferno-shared';
 import { ChildFlags, VNodeFlags } from 'inferno-vnode-flags';
 
@@ -69,6 +70,7 @@ export function createElement<P>(
     }
   }
   if (isString(type)) {
+    validateTagName(type);
     flags = getFlagsForElementVnode(type);
 
     if (!isNullOrUndef(props)) {
@@ -141,4 +143,9 @@ export function createElement<P>(
     key,
     ref,
   );
+}
+
+function validateTagName(type: string): void {
+  const regex = /[ \0 ><"]/g;
+  if (regex.test(type)) throwError(`Invalid tag name for element "<${type}>"`);
 }

--- a/packages/inferno-server/__tests__/StaticRouter.spec.server-nodom.tsx
+++ b/packages/inferno-server/__tests__/StaticRouter.spec.server-nodom.tsx
@@ -196,7 +196,7 @@ describe('A <StaticRouter>', () => {
   });
 
   describe('no basename', () => {
-    it('createHref does not append extra leading slash', () => {
+    it('createHref does not append extra leading slash', async () => {
       const context: Record<string, any> = {};
       const pathname = '/test-path-please-ignore';
 
@@ -213,7 +213,7 @@ describe('A <StaticRouter>', () => {
         />
       );
 
-      const outp = renderToStaticMarkup(
+      const outp = await renderToStaticMarkup(
         <StaticRouter context={context}>
           <Link to={pathname} />
         </StaticRouter>,
@@ -227,8 +227,8 @@ describe('A <StaticRouter>', () => {
     it('does nothing', () => {
       const context = {};
 
-      expect(() => {
-        renderToStaticMarkup(
+      expect(async () => {
+        await renderToStaticMarkup(
           <StaticRouter context={context}>
             <Prompt message="this is only a test" />
           </StaticRouter>,

--- a/packages/inferno-server/__tests__/animationHooks.spec.server.tsx
+++ b/packages/inferno-server/__tests__/animationHooks.spec.server.tsx
@@ -19,14 +19,15 @@ describe('SSR Creation (JSX)', () => {
       }
     }
 
-    const outp = renderToStaticMarkup(<App />);
+    renderToStaticMarkup(<App />).then((outp) => {  
+      // Doing this async to be sure
+      setTimeout(() => {
+        expect(spyer).toHaveBeenCalledTimes(0);
+        expect(outp).toEqual('<div></div>');
+        done();
+      }, 10);
+    });
 
-    // Doing this async to be sure
-    setTimeout(() => {
-      expect(spyer).toHaveBeenCalledTimes(0);
-      expect(outp).toEqual('<div></div>');
-      done();
-    }, 10);
   });
 
   it('should not call "componentDidAppear" when component is rendered with renderToString', (done) => {
@@ -42,14 +43,14 @@ describe('SSR Creation (JSX)', () => {
       }
     }
 
-    const outp = renderToString(<App />);
-
-    // Doing this async to be sure
-    setTimeout(() => {
-      expect(spyer).toHaveBeenCalledTimes(0);
-      expect(outp).toEqual('<div></div>');
-      done();
-    }, 10);
+    renderToString(<App />).then(outp => {
+      // Doing this async to be sure
+      setTimeout(() => {
+        expect(spyer).toHaveBeenCalledTimes(0);
+        expect(outp).toEqual('<div></div>');
+        done();
+      }, 10);
+    });
   });
 
   it('should not call "onComponentDidAppear" when component is rendered with renderToStaticMarkup', (done) => {
@@ -70,17 +71,17 @@ describe('SSR Creation (JSX)', () => {
       }
     }
 
-    const outp = renderToStaticMarkup(<App />);
-
-    // Doing this async to be sure
-    setTimeout(() => {
-      expect(spyer).toHaveBeenCalledTimes(0);
-      expect(outp).toEqual('<div></div>');
-      done();
-    }, 10);
+    renderToStaticMarkup(<App />).then(outp => {
+      // Doing this async to be sure
+      setTimeout(() => {
+        expect(spyer).toHaveBeenCalledTimes(0);
+        expect(outp).toEqual('<div></div>');
+        done();
+      }, 10);
+    });
   });
 
-  it('should not call "onComponentDidAppear" when component is rendered with renderToString', (done) => {
+  it('should not call "onComponentDidAppear" when component is rendered with renderToString',  (done) => {
     const spyer = jasmine.createSpy();
 
     const MyComp = () => {
@@ -98,13 +99,13 @@ describe('SSR Creation (JSX)', () => {
       }
     }
 
-    const outp = renderToString(<App />);
-
-    // Doing this async to be sure
-    setTimeout(() => {
-      expect(spyer).toHaveBeenCalledTimes(0);
-      expect(outp).toEqual('<div></div>');
-      done();
-    }, 10);
+    renderToString(<App />).then((outp) => {
+      // Doing this async to be sure
+      setTimeout(() => {
+        expect(spyer).toHaveBeenCalledTimes(0);
+        expect(outp).toEqual('<div></div>');
+        done();
+      }, 10);
+    });
   });
 });

--- a/packages/inferno-server/__tests__/creation.spec.server.ts
+++ b/packages/inferno-server/__tests__/creation.spec.server.ts
@@ -154,9 +154,9 @@ describe('SSR Creation (non-JSX)', () => {
   ];
 
   for (const test of testEntries) {
-    it(test.description, () => {
+    it(test.description, async () => {
       const vDom = test.template('foo');
-      const output = renderToStaticMarkup(vDom);
+      const output = await renderToStaticMarkup(vDom);
 
       expect(output).toBe(test.result);
     });

--- a/packages/inferno-server/__tests__/creation.spec.server.tsx
+++ b/packages/inferno-server/__tests__/creation.spec.server.tsx
@@ -217,16 +217,16 @@ describe('SSR Creation (JSX)', () => {
   ];
 
   for (const test of testEntries) {
-    it(test.description, () => {
+    it(test.description, async () => {
       const vDom = test.template();
-      const output = renderToStaticMarkup(vDom);
+      const output = await renderToStaticMarkup(vDom);
 
       expect(output).toBe(test.result);
     });
   }
 
   describe('Component hook', () => {
-    it('Should allow changing state in CWM', () => {
+    it('Should allow changing state in CWM', async () => {
       class Another extends Component {
         constructor(props, context) {
           super(props, context);
@@ -274,21 +274,21 @@ describe('SSR Creation (JSX)', () => {
 
       const vDom = <Tester />;
 
-      const output = renderToStaticMarkup(vDom);
+      const output = await renderToStaticMarkup(vDom);
 
       expect(output).toBe('<div>bar2<div>bar2</div></div>');
     });
   });
 
   describe('Component string output', () => {
-    it('Should render single text node', () => {
+    it('Should render single text node', async () => {
       class Foobar extends Component {
         render() {
           return 'foo';
         }
       }
 
-      const output = renderToString(
+      const output = await renderToString(
         <div>
           <Foobar />
         </div>
@@ -297,7 +297,7 @@ describe('SSR Creation (JSX)', () => {
       expect(output).toBe('<div>foo</div>');
     });
 
-    it('Should render single text node using state', () => {
+    it('Should render single text node using state', async () => {
       class Foobar extends Component {
         render() {
           return this.state!.text;
@@ -310,7 +310,7 @@ describe('SSR Creation (JSX)', () => {
         }
       }
 
-      const output = renderToString(
+      const output = await renderToString(
         <div>
           <Foobar />
         </div>
@@ -319,7 +319,7 @@ describe('SSR Creation (JSX)', () => {
       expect(output).toBe('<div>foo</div>');
     });
 
-    it('Should render single (number)text node using state', () => {
+    it('Should render single (number)text node using state', async () => {
       class Foobar extends Component {
         render() {
           return this.state!.text;
@@ -332,7 +332,7 @@ describe('SSR Creation (JSX)', () => {
         }
       }
 
-      const output = renderToString(
+      const output = await renderToString(
         <div>
           <Foobar />
         </div>
@@ -341,12 +341,12 @@ describe('SSR Creation (JSX)', () => {
       expect(output).toBe('<div>33</div>');
     });
 
-    it('Should render comment when component returns invalid node', () => {
+    it('Should render comment when component returns invalid node', async () => {
       function Foobar() {
         return null;
       }
 
-      const output = renderToString(
+      const output = await renderToString(
         <div>
           <Foobar />
         </div>
@@ -355,14 +355,14 @@ describe('SSR Creation (JSX)', () => {
       expect(output).toBe('<div><!--!--></div>');
     });
 
-    it('Should render single text node Class Component', () => {
+    it('Should render single text node Class Component', async () => {
       class Foobar extends Component {
         render() {
           return null;
         }
       }
 
-      const output = renderToString(
+      const output = await renderToString(
         <div>
           <Foobar />
         </div>
@@ -371,12 +371,12 @@ describe('SSR Creation (JSX)', () => {
       expect(output).toBe('<div><!--!--></div>');
     });
 
-    it('Should render single text node Functional Component', () => {
+    it('Should render single text node Functional Component', async () => {
       function Foobar() {
         return 'foo';
       }
 
-      const output = renderToString(
+      const output = await renderToString(
         <div>
           <Foobar />
         </div>
@@ -385,12 +385,12 @@ describe('SSR Creation (JSX)', () => {
       expect(output).toBe('<div>foo</div>');
     });
 
-    it('Should render single (number)text node Functional Component', () => {
+    it('Should render single (number)text node Functional Component', async () => {
       function Foobar() {
         return 2;
       }
 
-      const output = renderToString(
+      const output = await renderToString(
         <div>
           <Foobar />
         </div>
@@ -399,7 +399,7 @@ describe('SSR Creation (JSX)', () => {
       expect(output).toBe('<div>2</div>');
     });
 
-    it('Should render checked attribute for input when there is no checked in props', () => {
+    it('Should render checked attribute for input when there is no checked in props', async () => {
       class Foobar extends Component {
         render() {
           // @ts-expect-error
@@ -407,7 +407,7 @@ describe('SSR Creation (JSX)', () => {
         }
       }
 
-      const output = renderToString(
+      const output = await renderToString(
         <div>
           <Foobar />
         </div>
@@ -416,22 +416,22 @@ describe('SSR Creation (JSX)', () => {
       expect(output).toBe('<div><input count="1" type="checkbox" checked="true"></div>');
     });
 
-    it('Should throw error if invalid object is sent to renderToString', () => {
-      expect(() => renderToString({ failure: 'guaranteed' })).toThrow();
-      expect(() => renderToString(2)).toThrow();
+    it('Should throw error if invalid object is sent to renderToString', async () => {
+      await expect(() => renderToString({ failure: 'guaranteed' })).rejects.toThrow();
+      await expect(() => renderToString(2)).rejects.toThrow();
     });
 
-    it('Should re-use Css property names from cache when its used multiple times', () => {
-      expect(
+    it('Should re-use Css property names from cache when its used multiple times', async () => {
+      await expect(
         renderToString(
           <div style={{ 'background-color': 'red' }}>
             <div style={{ 'background-color': 'red' }} />
           </div>
         )
-      ).toEqual('<div style="background-color:red;"><div style="background-color:red;"></div></div>');
+      ).resolves.toEqual('<div style="background-color:red;"><div style="background-color:red;"></div></div>');
     });
 
-    it('text nodes should match 1:1 after hydration', () => {
+    it('text nodes should match 1:1 after hydration', async () => {
       class LinkComponent extends Component {
         render() {
           return (
@@ -443,7 +443,7 @@ describe('SSR Creation (JSX)', () => {
       }
       const container = document.createElement('div');
       const version = '4.0.0-21';
-      const renderedString = renderToString(
+      const renderedString = await renderToString(
         <div className="built">
           Website built with Inferno {version} using <LinkComponent />
         </div>
@@ -474,7 +474,7 @@ describe('SSR Creation (JSX)', () => {
       expect(wrapperDiv.childNodes[3]).toBe(AnchorNode);
     });
 
-    it('Should be possible to render Fragment #1', () => {
+    it('Should be possible to render Fragment #1', async () => {
       const vNode = (
         <div>
           {createFragment(
@@ -483,7 +483,7 @@ describe('SSR Creation (JSX)', () => {
           )}
         </div>
       );
-      const renderedString = renderToString(vNode);
+      const renderedString = await renderToString(vNode);
 
       expect(renderedString).toBe('<div><div>Lets go!</div><div>World</div>Of<em>Fragments</em>text node</div>');
 
@@ -499,7 +499,7 @@ describe('SSR Creation (JSX)', () => {
       expect(container.querySelector('em')).toBe(emTag);
     });
 
-    it('Should be possible to render Fragment #2', () => {
+    it('Should be possible to render Fragment #2', async () => {
       class Fragmented extends Component {
         render() {
           return createFragment([<div id="m">More</div>, 'Fragments'], ChildFlags.UnknownChildren);
@@ -521,7 +521,7 @@ describe('SSR Creation (JSX)', () => {
           )}
         </div>
       );
-      const renderedString = renderToString(vNode);
+      const renderedString = await renderToString(vNode);
 
       expect(renderedString).toBe('<div><div>Lets go!</div><div id="m">More</div>Fragments<div>World</div>Of<em>Fragments</em>text nodeGo<em>Code</em></div>');
 
@@ -562,7 +562,7 @@ describe('SSR Creation (JSX)', () => {
         }
       }
 
-      expect(renderToString(<Test />)).toBe('<div>1</div>');
+      expect(renderToString(<Test />)).resolves.toBe('<div>1</div>');
     });
   });
 });

--- a/packages/inferno-server/__tests__/hydration.spec.server.ts
+++ b/packages/inferno-server/__tests__/hydration.spec.server.ts
@@ -13,8 +13,8 @@ describe('SSR Hydration - (non-JSX)', () => {
   const expect1 = '<div><span>Hello world</span></div>';
   const expect2 = '<div><span>Hello world</span></div>';
 
-  it('Validate various structures', () => {
-    const html = renderToString(node);
+  it('Validate various structures', async () => {
+    const html = await renderToString(node);
     const container = createContainerWithHTML(html);
 
     expect(container.innerHTML).toBe(expect1);

--- a/packages/inferno-server/__tests__/hydration.spec.server.tsx
+++ b/packages/inferno-server/__tests__/hydration.spec.server.tsx
@@ -193,8 +193,8 @@ describe('SSR Hydration - (JSX)', () => {
       expect2: '<div><em>Works <span>again</span>!</em></div>'
     }
   ].forEach(({ node, expect1, expect2 }, i) => {
-    it(`Validate various structures #${i + 1}`, () => {
-      const html = renderToString(node);
+    it(`Validate various structures #${i + 1}`, async () => {
+      const html = await renderToString(node);
       const container = createContainerWithHTML(html);
 
       expect(container.innerHTML).toBe(expect1);
@@ -379,8 +379,8 @@ describe('SSR Hydration - (JSX)', () => {
       expect3: '<div></div>'
     }
   ].forEach(({ node, expect1, node2, node3, expect2, expect3 }, i) => {
-    it(`Update various structures #${i + 1}`, () => {
-      const html = renderToString(node);
+    it(`Update various structures #${i + 1}`, async () => {
+      const html = await renderToString(node);
       const container = createContainerWithHTML(html);
 
       expect(container.innerHTML).toBe(expect1);
@@ -1031,8 +1031,8 @@ describe('SSR Hydration - (JSX)', () => {
         CSR2_expected: '<div><span>B</span></div>'
       }
     ].forEach(({ SSR, CSR, CSR2, SSR_expected, CSR_expected, CSR2_expected }, i) => {
-      it(`Validate various structures #${i + 1}`, () => {
-        const ssrString = renderToString(SSR);
+      it(`Validate various structures #${i + 1}`, async () => {
+        const ssrString = await renderToString(SSR);
         const SsrContainer = createContainerWithHTML(ssrString);
 
         expect(SsrContainer.innerHTML).toBe(SSR_expected);

--- a/packages/inferno-server/__tests__/loaderOnRoute.spec.server.tsx
+++ b/packages/inferno-server/__tests__/loaderOnRoute.spec.server.tsx
@@ -49,7 +49,7 @@ describe('Resolve loaders during server side rendering', () => {
     const initialData = await resolveLoaders(loaderEntries);
 
     // Render on server
-    const html = renderToString(
+    const html = await renderToString(
       <StaticRouter context={{}} location="/birds" initialData={initialData}>
         {routes}
       </StaticRouter>,

--- a/packages/inferno-server/__tests__/observer.spec.server.tsx
+++ b/packages/inferno-server/__tests__/observer.spec.server.tsx
@@ -17,7 +17,7 @@ describe('Mobx Observer Server', () => {
     document.body.removeChild(container);
   });
 
-  it('does not views alive when using static + string rendering', function () {
+  it('does not views alive when using static + string rendering', async function () {
     useStaticRendering(true);
 
     let renderCount = 0;
@@ -30,7 +30,7 @@ describe('Mobx Observer Server', () => {
       return <div>{data.z}</div>;
     });
 
-    const output = renderToStaticMarkup(<TestComponent />);
+    const output = await renderToStaticMarkup(<TestComponent />);
 
     data.z = 'hello';
 

--- a/packages/inferno-server/__tests__/props-context.spec.server.tsx
+++ b/packages/inferno-server/__tests__/props-context.spec.server.tsx
@@ -12,7 +12,7 @@ describe('SSR render() arguments', () => {
     }
   }
 
-  it('should have props as 1st argument', () => {
+  it('should have props as 1st argument', async () => {
     interface TestChildProps {
       testProps: string
     }
@@ -23,11 +23,11 @@ describe('SSR render() arguments', () => {
       }
     }
 
-    const output = renderToStaticMarkup(<TestChild testProps="props-works" />);
+    const output = await renderToStaticMarkup(<TestChild testProps="props-works" />);
     expect(output).toBe('<p>props-works</p>');
   });
 
-  it('should have state as 2nd argument', () => {
+  it('should have state as 2nd argument', async () => {
     class TestChild extends Component {
 
       constructor() {
@@ -39,18 +39,18 @@ describe('SSR render() arguments', () => {
         return <p>{state.testState}</p>;
       }
     }
-    const output = renderToStaticMarkup(<TestChild />);
+    const output = await renderToStaticMarkup(<TestChild />);
     expect(output).toBe('<p>state-works</p>');
   });
 
-  it('statefull has context as 3rd argument', () => {
+  it('statefull has context as 3rd argument', async () => {
     class TestChild extends Component {
       render(_props, _state, context) {
         return <p>{context.testContext}</p>;
       }
     }
 
-    const output = renderToStaticMarkup(
+    const output = await renderToStaticMarkup(
       <TestProvider>
         <TestChild />
       </TestProvider>,
@@ -58,12 +58,12 @@ describe('SSR render() arguments', () => {
     expect(output).toBe('<p>context-works</p>');
   });
 
-  it('stateless has context as 2nd argument', () => {
+  it('stateless has context as 2nd argument', async () => {
     function TestChild(_props, context) {
       return <p>{context.testContext}</p>;
     }
 
-    const output = renderToStaticMarkup(
+    const output = await renderToStaticMarkup(
       <TestProvider>
         <TestChild />
       </TestProvider>,
@@ -71,7 +71,7 @@ describe('SSR render() arguments', () => {
     expect(output).toBe('<p>context-works</p>');
   });
 
-  it('nested stateless has context as 2nd argument', () => {
+  it('nested stateless has context as 2nd argument', async () => {
 
     function ChildWrapper(props) {
       return props.children;
@@ -79,7 +79,7 @@ describe('SSR render() arguments', () => {
     function TestChild(_props, context) {
       return <p>{context.testContext}</p>;
     }
-    const output = renderToStaticMarkup(
+    const output = await renderToStaticMarkup(
       <TestProvider>
         <ChildWrapper>
           <ChildWrapper>
@@ -91,7 +91,7 @@ describe('SSR render() arguments', () => {
     expect(output).toBe('<p>context-works</p>');
   });
 
-  it('nested providers should have merged context', () => {
+  it('nested providers should have merged context', async () => {
     class TestContext extends Component {
       getChildContext() {
         return { testContextWrap: 'context-wrap-works' };
@@ -108,7 +108,7 @@ describe('SSR render() arguments', () => {
         </p>
       );
     }
-    const output = renderToStaticMarkup(
+    const output = await renderToStaticMarkup(
       <TestProvider>
         <TestContext>
           <TestChild />

--- a/packages/inferno-server/__tests__/ssr-forwardref.spec.tsx
+++ b/packages/inferno-server/__tests__/ssr-forwardref.spec.tsx
@@ -28,8 +28,8 @@ describe('SSR -> Hydrate - Forward Ref', () => {
     document.body.removeChild(container);
   });
 
-  function SSRtoString(method, vNode, callback) {
-    const val = method(vNode);
+  async function SSRtoString(method, vNode, callback) {
+    const val = await method(vNode);
 
     if (isString(val)) {
       callback(val);
@@ -91,7 +91,7 @@ describe('SSR -> Hydrate - Forward Ref', () => {
         );
 
         done();
-      });
+      }).then(() => {});
     });
 
     it('Should be possible to forward callback ref', (done) => {

--- a/packages/inferno-server/__tests__/utils.spec.server.tsx
+++ b/packages/inferno-server/__tests__/utils.spec.server.tsx
@@ -4,13 +4,13 @@ import { createContainerWithHTML, validateNodeTree } from 'inferno-utils';
 
 describe('Utils - SSR', () => {
   describe('validateNodeTree', () => {
-    it('should return true on a valid node tree', () => {
+    it('should return true on a valid node tree', async () => {
       const node = (
         <div>
           <span>Hello world</span>
         </div>
       );
-      const html = renderToString(node);
+      const html = await renderToString(node);
       const container = createContainerWithHTML(html);
       render(node, container);
       expect(validateNodeTree(node)).toBe(true);

--- a/packages/inferno-server/src/renderToString.ts
+++ b/packages/inferno-server/src/renderToString.ts
@@ -19,7 +19,11 @@ import {
   voidElements,
 } from './utils';
 
-function renderVNodeToString(vNode, parent, context): string {
+async function renderVNodeToString(vNode, parent, context): Promise<string> {
+  if (vNode.then) {
+    vNode = await vNode;
+  }
+
   const flags = vNode.flags;
   const type = vNode.type;
   const props = vNode.props || EMPTY_OBJ;
@@ -86,7 +90,7 @@ function renderVNodeToString(vNode, parent, context): string {
       if (isNumber(renderOutput)) {
         return renderOutput + '';
       }
-      return renderVNodeToString(renderOutput, vNode, childContext);
+      return await renderVNodeToString(renderOutput, vNode, childContext);
     } else {
       const renderOutput = renderFunctionalComponent(vNode, context);
 
@@ -99,7 +103,7 @@ function renderVNodeToString(vNode, parent, context): string {
       if (isNumber(renderOutput)) {
         return renderOutput + '';
       }
-      return renderVNodeToString(renderOutput, vNode, context);
+      return await renderVNodeToString(renderOutput, vNode, context);
     }
   } else if ((flags & VNodeFlags.Element) !== 0) {
     let renderedString = `<${type}`;
@@ -175,10 +179,14 @@ function renderVNodeToString(vNode, parent, context): string {
       const childFlags = vNode.childFlags;
 
       if (childFlags === ChildFlags.HasVNodeChildren) {
-        renderedString += renderVNodeToString(children, vNode, context);
+        renderedString += await renderVNodeToString(children, vNode, context);
       } else if (childFlags & ChildFlags.MultipleChildren) {
         for (let i = 0, len = children.length; i < len; ++i) {
-          renderedString += renderVNodeToString(children[i], vNode, context);
+          renderedString += await renderVNodeToString(
+            children[i],
+            vNode,
+            context,
+          );
         }
       } else if (childFlags === ChildFlags.HasTextChildren) {
         renderedString += children === '' ? ' ' : escapeText(children);
@@ -211,7 +219,11 @@ function renderVNodeToString(vNode, parent, context): string {
       let renderedString = '';
 
       for (let i = 0, len = tmpNodes.length; i < len; ++i) {
-        renderedString += renderVNodeToString(tmpNodes[i], vNode, context);
+        renderedString += await renderVNodeToString(
+          tmpNodes[i],
+          vNode,
+          context,
+        );
       }
 
       return renderedString;
@@ -236,6 +248,6 @@ function renderVNodeToString(vNode, parent, context): string {
   return '';
 }
 
-export function renderToString(input: any): string {
-  return renderVNodeToString(input, {}, {});
+export async function renderToString(input: any): Promise<string> {
+  return await renderVNodeToString(input, {}, {});
 }


### PR DESCRIPTION
## Async component rendering

**Objective 1**
This PR aims to support async component rendering through the `renderToString` function.

Problem:
```tsx
class RootElem extends Component {
  render() {
    return <>
        <div>Test</div>
        {this.props.children}
    </>
  }
}

class AsyncElem extends Component {
  async render() {
    // do something async...
    return <>
        <div>Async Elem</div>
    </>
  }
}

console.log(
  <RootElem>
    <AsyncElem />
  </RootElem>
);
```

In the example above, Inferno complains and throw a error because `AsyncElem.render()` is a `Promise<...>`. The PR changes `renderVNodeToString(vNode, parent, context)` to resolve `vNode` as soon as possible to continue the operation normally.

**Objective 2**
While changing the test cases, i found a specific test case which is not fullfilled in `Security - SSR > renderToString > Should not render invalid tagNames`.

**Closes Issue**
(no issue found)
