### PR TITLE
Backport fix for events not registered in shadow dom to v5

### DIFF
--- a/packages/inferno/__tests__/shadowdom.spec.jsx
+++ b/packages/inferno/__tests__/shadowdom.spec.jsx
@@ -1,0 +1,35 @@
+import { render } from 'inferno';
+import sinon from 'sinon';
+
+describe('Shadow DOM', () => {
+  let container;
+
+  beforeEach(function() {
+    container = document.createElement('div');
+    document.body.appendChild(container);
+  });
+
+  afterEach(function() {
+    render(null, container);
+    container.innerHTML = '';
+    document.body.removeChild(container);
+  });
+
+  it('Should propagate events through shadow dom boundaries', () => {
+    // Run these tests only in environments which support shadow-dom
+    if (!container.attachShadow) {
+      return;
+    }
+
+    const spyObj = { fn: () => {} };
+    const spy1 = sinon.spy(spyObj, 'fn');
+
+    const shadowRoot = container.attachShadow({ mode: 'open' });
+
+    render(<button onClick={spy1}>Log</button>, shadowRoot);
+
+    shadowRoot.querySelector('button').click();
+
+    expect(spy1.callCount).toBe(1);
+  });
+});

--- a/packages/inferno/src/DOM/events/delegation.ts
+++ b/packages/inferno/src/DOM/events/delegation.ts
@@ -1,4 +1,4 @@
-import { isNull } from 'inferno-shared';
+import { isFunction, isNull } from 'inferno-shared';
 import { SemiSyntheticEvent } from 'inferno';
 
 const attachedEventCounts = {};
@@ -33,8 +33,20 @@ export function handleEvent(name: string, nextEvent: Function | null, dom) {
   }
 }
 
-function dispatchEvents(event: SemiSyntheticEvent<any>, target, isClick: boolean, name: string, eventData: IEventData) {
-  let dom = target;
+// When browsers fully support event.composedPath we could loop it through instead of using parentNode property
+function getTargetNode(event) {
+  return isFunction(event.composedPath)
+    ? event.composedPath()[0]
+    : event.target;
+}
+
+function dispatchEvents(
+  event: SemiSyntheticEvent<any>,
+  isClick: boolean,
+  name: string,
+  eventData: IEventData
+) {
+  let dom = getTargetNode(event);
   while (!isNull(dom)) {
     // Html Nodes can be nested fe: span inside button in that scenario browser does not handle disabled attribute on parent,
     // because the event listener is on document.body
@@ -101,7 +113,7 @@ function attachEventToDocument(name: string) {
       }
     });
 
-    dispatchEvents(event, event.target, isClick, name, eventData);
+    dispatchEvents(event, isClick, name, eventData);
     return;
   };
   document.addEventListener(normalizeEventName(name), docEvent);


### PR DESCRIPTION
 **Objective**

This PR backports the fix for events not being registered in the shadow dom to v5. It would be great if this backport could be released as a new minor version of v5, so the dmn-js library can upgrade to that new minor version of v5, and make click events work without a major upgrade being needed.

**Closes Issue**

This is a backport of the fix of issue [#1430](https://github.com/infernojs/inferno/issues/1430)
It is needed to fix event handling issues in the dmn-js library https://github.com/bpmn-io/dmn-js/issues/631
