### PR TITLE
Change default class component props type from object to Record

### DIFF
--- a/packages/inferno/__tests__/linkEvent.spec.tsx
+++ b/packages/inferno/__tests__/linkEvent.spec.tsx
@@ -90,7 +90,6 @@ describe('linkEvent', () => {
     });
 
     it('should work correctly for stateful components', () => {
-      // @ts-expect-error
       render(<StatefulComponent test="456" />, container);
       container.querySelector('button').click();
       expect(test).toBe('456');

--- a/packages/inferno/src/core/component.ts
+++ b/packages/inferno/src/core/component.ts
@@ -135,7 +135,7 @@ export type ComponentType<P = Record<string, unknown>> =
   | typeof Component<P>
   | Inferno.StatelessComponent<P>;
 
-export abstract class Component<P = object, S = Record<string, unknown>>
+export abstract class Component<P = Record<string, any>, S = Record<string, unknown>>
   implements IComponent<P, S>
 {
   // Public

--- a/packages/inferno/src/core/component.ts
+++ b/packages/inferno/src/core/component.ts
@@ -135,7 +135,7 @@ export type ComponentType<P = Record<string, unknown>> =
   | typeof Component<P>
   | Inferno.StatelessComponent<P>;
 
-export abstract class Component<P = Record<string, any>, S = Record<string, unknown>>
+export abstract class Component<P = Record<string, unknown>, S = Record<string, unknown>>
   implements IComponent<P, S>
 {
   // Public


### PR DESCRIPTION
Change default class component props type from object to Record<string, any> to allow giving a JS component props in a TS file. Earlier the props type was `{}` which worked fine I guess. Now in version 9 it was changed to `object`, which started to cause problems described in issue #1675. Changing the prop type to Record<string, any> seemed to solve the problems. Probably worth while to check that it des not suppress too much type checking where it is wanted.

 *Before* submitting a PR please:
 - Include tests for the functionality you are adding! See CONTRIBUTING.md for details how to run tests.
 - Run `npm run build` and check that the build succeeds.
 - Ensure that the PR hasn't been submitted before.

---

## PR Template

**Objective**

This PR fixes issue #1675

**Closes Issue**

It closes Issue #1675
