### PR TITLE
fix: defaultvalue overwrites input value (#1689)

### DIFF
--- a/packages/inferno/__tests__/patching.spec.tsx
+++ b/packages/inferno/__tests__/patching.spec.tsx
@@ -817,6 +817,8 @@ describe('patching routine', () => {
         expect(container.innerHTML).toBe('<input type="text" id="start" value="start">')
 
         container.firstChild.value = 'changed';
+        render(input('start'), container);
+        expect(container.firstChild.value).toBe('changed');
 
         render(input('end'), container);
         expect(container.innerHTML).toBe('<input type="text" id="end" value="end">')

--- a/packages/inferno/src/DOM/patching.ts
+++ b/packages/inferno/src/DOM/patching.ts
@@ -376,6 +376,7 @@ export function patchElement(
       nextPropsOrEmpty,
       false,
       hasControlledValue,
+      lastProps.id !== nextProps.id
     );
   }
 

--- a/packages/inferno/src/DOM/wrappers/InputWrapper.ts
+++ b/packages/inferno/src/DOM/wrappers/InputWrapper.ts
@@ -27,7 +27,7 @@ export function inputEvents(dom, nextPropsOrEmpty): void {
   }
 }
 
-export function applyValueInput(nextPropsOrEmpty, dom): void {
+export function applyValueInput(nextPropsOrEmpty, dom, isIdChanged): void {
   const type = nextPropsOrEmpty.type;
   const value = nextPropsOrEmpty.value;
   const checked = nextPropsOrEmpty.checked;
@@ -42,7 +42,7 @@ export function applyValueInput(nextPropsOrEmpty, dom): void {
     dom.multiple = multiple;
   }
   if (!isNullOrUndef(defaultValue) && !hasValue) {
-    if (defaultValue !== dom.value) {
+    if (isIdChanged && defaultValue !== dom.value) {
       dom.value = defaultValue + '';
     }
     dom.defaultValue = defaultValue + '';

--- a/packages/inferno/src/DOM/wrappers/processElement.ts
+++ b/packages/inferno/src/DOM/wrappers/processElement.ts
@@ -12,9 +12,10 @@ export function processElement(
   nextPropsOrEmpty,
   mounting: boolean,
   isControlled: boolean,
+  isIdChanged?: boolean,
 ): void {
   if ((flags & VNodeFlags.InputElement) !== 0) {
-    applyValueInput(nextPropsOrEmpty, dom);
+    applyValueInput(nextPropsOrEmpty, dom, isIdChanged);
   } else if ((flags & VNodeFlags.SelectElement) !== 0) {
     applyValueSelect(nextPropsOrEmpty, dom, mounting, vNode);
   } else if ((flags & VNodeFlags.TextareaElement) !== 0) {


### PR DESCRIPTION
**Objective** resolve https://github.com/infernojs/inferno/issues/1689 only reset an input's defaultValue if the id has changed

**Closes Issue** It closes Issue #1689 
